### PR TITLE
feat: migrate debate store from JSON files to PostgreSQL (#33) + fix …

### DIFF
--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -135,7 +135,12 @@ class CachedDebate(Base):
 class DebateLike(Base):
     __tablename__ = "debate_likes"
     id = Column(Integer, primary_key=True, autoincrement=True)
-    debate_id = Column(String(255), nullable=False, index=True)
+    debate_id = Column(
+        String(255),
+        ForeignKey("cached_debates.debate_id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
     user_email = Column(String(255), nullable=False)
     created_at = Column(DateTime, default=datetime.utcnow)
 

--- a/backend/app/debate/store.py
+++ b/backend/app/debate/store.py
@@ -194,43 +194,50 @@ async def get_like_count(debate_id: str) -> int:
 
 
 async def like_debate(debate_id: str, user_email: str) -> bool:
-    """Toggle like for a debate. Returns True if now liked, False if unliked."""
+    """
+    Toggle like for a debate atomically.
+
+    Uses INSERT ... ON CONFLICT DO NOTHING to avoid a read-then-write race
+    condition: if the insert lands (rowcount == 1), the debate is now liked;
+    if nothing was inserted (rowcount == 0), the row already existed and we
+    delete it (unlike).
+
+    Returns True if now liked, False if unliked.
+    """
     _validate_debate_id(debate_id)
 
     try:
         factory = _get_session_factory()
         async with factory() as session:
-            # Check if already liked
-            result = await session.execute(
-                select(DebateLike.id).where(
-                    DebateLike.debate_id == debate_id,
-                    DebateLike.user_email == user_email,
-                )
-            )
-            existing = result.scalar_one_or_none()
+            # Attempt atomic insert; no-op on duplicate
+            stmt = pg_insert(DebateLike).values(
+                debate_id=debate_id,
+                user_email=user_email,
+                created_at=datetime.now(timezone.utc),
+            ).on_conflict_do_nothing(index_elements=["debate_id", "user_email"])
+            result = await session.execute(stmt)
 
-            if existing is not None:
-                # Unlike
+            if result.rowcount == 1:
+                # Row was inserted → user just liked the debate
+                await session.commit()
+                return True
+            else:
+                # Row already existed → user is unliking; delete it
                 await session.execute(
-                    sa_delete(DebateLike).where(DebateLike.id == existing)
+                    sa_delete(DebateLike).where(
+                        DebateLike.debate_id == debate_id,
+                        DebateLike.user_email == user_email,
+                    )
                 )
                 await session.commit()
                 return False
-            else:
-                # Like
-                session.add(DebateLike(
-                    debate_id=debate_id,
-                    user_email=user_email,
-                ))
-                await session.commit()
-                return True
     except Exception as exc:
         logger.warning("DB unavailable, like_debate('%s', '%s'): %s", debate_id, user_email, exc)
         return False
 
 
 async def delete_debate(debate_id: str) -> bool:
-    """Delete a debate from the store. Returns True if deleted."""
+    """Delete a debate and its associated likes from the store. Returns True if deleted."""
     try:
         _validate_debate_id(debate_id)
     except ValueError:
@@ -239,6 +246,10 @@ async def delete_debate(debate_id: str) -> bool:
     try:
         factory = _get_session_factory()
         async with factory() as session:
+            # Delete associated likes first (in case FK cascade is not yet applied)
+            await session.execute(
+                sa_delete(DebateLike).where(DebateLike.debate_id == debate_id)
+            )
             result = await session.execute(
                 sa_delete(CachedDebate).where(
                     CachedDebate.debate_id == debate_id
@@ -249,3 +260,54 @@ async def delete_debate(debate_id: str) -> bool:
     except Exception as exc:
         logger.warning("DB unavailable, delete_debate('%s'): %s", debate_id, exc)
         return False
+
+
+async def get_bulk_like_counts(debate_ids: List[str]) -> Dict[str, int]:
+    """
+    Get like counts for multiple debates in a single query.
+
+    Returns a dict mapping debate_id → like count. Debates with zero
+    likes are omitted from the result; callers should default to 0.
+    """
+    if not debate_ids:
+        return {}
+
+    try:
+        factory = _get_session_factory()
+        async with factory() as session:
+            result = await session.execute(
+                select(DebateLike.debate_id, func.count().label("cnt"))
+                .where(DebateLike.debate_id.in_(debate_ids))
+                .group_by(DebateLike.debate_id)
+            )
+            return {row[0]: row[1] for row in result.all()}
+    except Exception as exc:
+        logger.warning("DB unavailable, get_bulk_like_counts: %s", exc)
+        return {}
+
+
+async def get_bulk_user_liked(
+    debate_ids: List[str], user_email: str
+) -> Dict[str, bool]:
+    """
+    Check which debates a user has liked in a single query.
+
+    Returns a dict mapping debate_id → bool.
+    """
+    if not debate_ids:
+        return {}
+
+    try:
+        factory = _get_session_factory()
+        async with factory() as session:
+            result = await session.execute(
+                select(DebateLike.debate_id).where(
+                    DebateLike.debate_id.in_(debate_ids),
+                    DebateLike.user_email == user_email,
+                )
+            )
+            liked_ids = {row[0] for row in result.all()}
+            return {d: d in liked_ids for d in debate_ids}
+    except Exception as exc:
+        logger.warning("DB unavailable, get_bulk_user_liked: %s", exc)
+        return {}

--- a/backend/app/routes/debates.py
+++ b/backend/app/routes/debates.py
@@ -5,7 +5,10 @@ from fastapi.responses import StreamingResponse, JSONResponse
 
 from app.config import settings
 from app.debate.stream import stream_debate_events
-from app.debate.store import load_debate, list_debates, like_debate, get_like_count, get_likes, save_debate
+from app.debate.store import (
+    load_debate, list_debates, like_debate, get_like_count,
+    get_bulk_like_counts, get_bulk_user_liked, save_debate,
+)
 from app.judging.panel import run_judging_panel
 
 router = APIRouter(prefix="/api/debates", tags=["debates"])
@@ -41,12 +44,17 @@ async def get_all_debates(authorization: Optional[str] = Header(None)):
     """
     user_email = _get_user_email(authorization)
     debates = await list_debates()
+    if not debates:
+        return debates
+
+    debate_ids = [d["id"] for d in debates]
+    like_counts = await get_bulk_like_counts(debate_ids)
+    user_liked = (
+        await get_bulk_user_liked(debate_ids, user_email) if user_email else {}
+    )
     for d in debates:
-        d["like_count"] = await get_like_count(d["id"])
-        if user_email:
-            d["user_liked"] = user_email in await get_likes(d["id"])
-        else:
-            d["user_liked"] = False
+        d["like_count"] = like_counts.get(d["id"], 0)
+        d["user_liked"] = user_liked.get(d["id"], False)
     return debates
 
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -6,8 +6,6 @@ Provides:
 - Mock Anthropic client to prevent real API calls
 - Sample debate state and data factories
 """
-import os
-import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest

--- a/backend/tests/unit/test_store.py
+++ b/backend/tests/unit/test_store.py
@@ -3,7 +3,6 @@ Tests for debate persistence store — store.py.
 Uses mock async sessions to test PostgreSQL-backed storage logic
 without requiring a live database connection.
 """
-from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -155,6 +154,8 @@ async def test_delete_debate_success(patch_session_factory):
     session.execute.return_value = mock_result
 
     assert await store.delete_debate("del-me") is True
+    # execute called twice: once for likes delete, once for debate delete
+    assert session.execute.call_count == 2
     session.commit.assert_called_once()
 
 
@@ -175,27 +176,27 @@ async def test_delete_invalid_id():
 
 async def test_like_toggle_on(patch_session_factory):
     session = patch_session_factory
-    # No existing like → should add one
+    # INSERT ... ON CONFLICT DO NOTHING inserts a new row (rowcount == 1) → liked
     mock_result = MagicMock()
-    mock_result.scalar_one_or_none.return_value = None
+    mock_result.rowcount = 1
     session.execute.return_value = mock_result
 
     result = await store.like_debate("likeable", "user@test.com")
     assert result is True
-    session.add.assert_called_once()
+    session.execute.assert_called_once()
     session.commit.assert_called_once()
 
 
 async def test_like_toggle_off(patch_session_factory):
     session = patch_session_factory
-    # Existing like → should remove it
+    # INSERT ... ON CONFLICT DO NOTHING does nothing (rowcount == 0) → already liked, so unlike
     mock_result = MagicMock()
-    mock_result.scalar_one_or_none.return_value = 42  # existing like id
+    mock_result.rowcount = 0
     session.execute.return_value = mock_result
 
     result = await store.like_debate("likeable", "user@test.com")
     assert result is False
-    # execute called twice: once for select, once for delete
+    # execute called twice: once for atomic insert attempt, once for delete
     assert session.execute.call_count == 2
     session.commit.assert_called_once()
 
@@ -219,6 +220,43 @@ async def test_get_likes(patch_session_factory):
     likes = await store.get_likes("popular")
     assert "a@test.com" in likes
     assert "b@test.com" in likes
+
+
+# ── bulk like helpers ────────────────────────────────────────────────────
+
+async def test_get_bulk_like_counts(patch_session_factory):
+    session = patch_session_factory
+    mock_result = MagicMock()
+    mock_result.all.return_value = [("debate-a", 5), ("debate-b", 2)]
+    session.execute.return_value = mock_result
+
+    counts = await store.get_bulk_like_counts(["debate-a", "debate-b", "debate-c"])
+    assert counts["debate-a"] == 5
+    assert counts["debate-b"] == 2
+    assert "debate-c" not in counts  # zero-like debates are omitted
+
+
+async def test_get_bulk_like_counts_empty_input(patch_session_factory):
+    counts = await store.get_bulk_like_counts([])
+    assert counts == {}
+
+
+async def test_get_bulk_user_liked(patch_session_factory):
+    session = patch_session_factory
+    mock_result = MagicMock()
+    mock_result.all.return_value = [("debate-a",)]
+    session.execute.return_value = mock_result
+
+    result = await store.get_bulk_user_liked(
+        ["debate-a", "debate-b"], "user@test.com"
+    )
+    assert result["debate-a"] is True
+    assert result["debate-b"] is False
+
+
+async def test_get_bulk_user_liked_empty_input(patch_session_factory):
+    result = await store.get_bulk_user_liked([], "user@test.com")
+    assert result == {}
 
 
 # ── validation / security ──────────────────────────────────────────────


### PR DESCRIPTION
…spacebar bug (#32)

- Add CachedDebate and DebateLike models to db/models.py (JSONB storage)
- Rewrite store.py: all functions now async, using PostgreSQL instead of files
- Graceful fallback: store functions return empty/None when DB is unreachable
- Update stream.py and routes/debates.py callers to await store functions
- Add debate seeding from local JSON files on first startup (main.py lifespan)
- Add Issues #32 and #33 to github-issues.md
- Fix spacebar bug in custom topic input (page.tsx)
- Update all tests to use mock async DB store instead of temp file dirs
- Fix pre-existing AsyncSessionLocal import in test_votes.py