### PR TITLE
feat(frontend): UI redesign — Intellectual Modernism design system

### DIFF
--- a/Docs/superpowers/plans/2026-03-24-ui-redesign.md
+++ b/Docs/superpowers/plans/2026-03-24-ui-redesign.md
@@ -1,0 +1,1128 @@
+# UI Redesign — Ink, Gold & Sapphire Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the generic cyan/fuchsia vibe-coded aesthetic with an editorial-meets-theatrical design system (Ink, Gold & Sapphire) across all frontend pages and components.
+
+**Architecture:** Pure styling change — CSS custom property tokens defined in `globals.css`, consumed via Tailwind arbitrary values and inline styles throughout components. Dark mode default via `data-theme="dark"` on `<html>`, toggled by JS and persisted to `localStorage`. No component structure, routing, or state changes.
+
+**Tech Stack:** Next.js 15, Tailwind CSS v4, Google Fonts (Playfair Display, Lora, Inter), CSS custom properties
+
+**Spec:** `Docs/superpowers/specs/2026-03-24-ui-redesign-design.md`
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `frontend/src/app/globals.css` | Modify | CSS tokens (both themes), keyframe animations, base utility classes |
+| `frontend/src/app/layout.tsx` | Modify | Font imports, masthead rule div, theme-init script |
+| `frontend/src/app/page.tsx` | Modify | Landing hero (centered, new type), ornament divider |
+| `frontend/src/app/debates/[id]/page.tsx` | Modify | Background layers, phase nav, debate header, score row, split columns |
+| `frontend/src/app/debates/new/page.tsx` | Modify | Token-based colors, typography |
+| `frontend/src/app/browse/page.tsx` | Modify | Token-based colors, typography |
+| `frontend/src/app/dashboard/page.tsx` | Modify | Token-based colors, typography |
+| `frontend/src/app/auth/page.tsx` | Modify | Token-based colors, typography |
+| `frontend/src/components/debate/ArgumentCard.tsx` | Modify | Card layout, avatar, header, Lora body text |
+| `frontend/src/components/debate/PhaseNav.tsx` | Modify | Phase nav styling, completed indicator color |
+| `frontend/src/components/debate/StreamingText.tsx` | Modify | Cursor color, bold text color |
+| `frontend/src/components/debate/CitationBadge.tsx` | Modify | Gold/neutral palette replacing cyan |
+| `frontend/src/components/debate/StrategicAnalysisPanel.tsx` | Modify | Gold/blue replacing cyan/fuchsia |
+| `frontend/src/components/dashboard/HistoryCard.tsx` | Modify | Winner badge, score dots |
+| `frontend/tests/components/Home.test.tsx` | Modify | Update snapshot if needed |
+| `frontend/tests/components/Dashboard.test.tsx` | Modify | Update snapshot if needed |
+
+---
+
+## Task 1: CSS Foundation — Tokens, Keyframes & Base Styles
+
+**Files:**
+- Modify: `frontend/src/app/globals.css`
+
+This is the foundation everything else depends on. Do this first.
+
+- [ ] **Step 1: Replace globals.css entirely**
+
+Replace the full contents of `frontend/src/app/globals.css` with:
+
+```css
+@import "tailwindcss";
+@plugin "@tailwindcss/typography";
+
+/* ─── DARK MODE TOKENS ─── */
+[data-theme="dark"] {
+  --bg:         #0c0c10;
+  --bg2:        #13131a;
+  --bg3:        #1c1c26;
+  --gold:       #c9a84c;
+  --gold-lt:    #e8c97a;
+  --gold-dim:   rgba(201, 168, 76, 0.13);
+  --blue:       #2a6db5;
+  --blue-lt:    #5a9fe0;
+  --blue-dim:   rgba(42, 109, 181, 0.13);
+  --text:       #f2ead6;
+  --text-2:     #d4c9ae;
+  --text-ui:    #8a7a60;
+  --border:     rgba(255, 255, 255, 0.1);
+  --border-dim: rgba(255, 255, 255, 0.07);
+}
+
+/* ─── LIGHT MODE TOKENS ─── */
+[data-theme="light"] {
+  --bg:         #ffffff;
+  --bg2:        #f7f7f5;
+  --bg3:        #eeeeea;
+  --gold:       #8a5e0a;
+  --gold-lt:    #a87214;
+  --gold-dim:   rgba(138, 94, 10, 0.08);
+  --blue:       #0f4080;
+  --blue-lt:    #1a5aa8;
+  --blue-dim:   rgba(15, 64, 128, 0.08);
+  --text:       #0a0a0a;
+  --text-2:     #1a1a1a;
+  --text-ui:    #767676;
+  --border:     rgba(0, 0, 0, 0.15);
+  --border-dim: rgba(0, 0, 0, 0.08);
+}
+
+/* ─── BASE ─── */
+body {
+  background: var(--bg);
+  color: var(--text);
+  font-family: 'Inter', Arial, sans-serif;
+  transition: background 0.5s, color 0.5s;
+}
+
+/* ─── BACKGROUND ANIMATIONS (dark only) ─── */
+[data-theme="light"] .bg-breathe,
+[data-theme="light"] .bg-grain,
+[data-theme="light"] .bg-vignette {
+  opacity: 0 !important;
+  pointer-events: none;
+}
+
+@keyframes breathe-gold {
+  0%,  100% { transform: scale(1)    translate(0,      0);       opacity: 0.8; }
+  33%        { transform: scale(1.2)  translate(1.5vw,  1vw);     opacity: 1;   }
+  66%        { transform: scale(0.9)  translate(-1vw,  -0.5vw);   opacity: 0.5; }
+}
+@keyframes breathe-blue {
+  0%,  100% { transform: scale(1)    translate(0,      0);        opacity: 0.7; }
+  40%        { transform: scale(1.25) translate(-1.5vw, 1vw);     opacity: 1;   }
+  70%        { transform: scale(0.85) translate(1vw,   -1.5vw);   opacity: 0.4; }
+}
+@keyframes breathe-mid {
+  0%,  100% { transform: scale(1);    opacity: 0.35; }
+  50%        { transform: scale(1.35); opacity: 0.7;  }
+}
+@keyframes grain-shift {
+  0%   { transform: translate(0,      0);      }
+  12%  { transform: translate(-1.5%, -2%);     }
+  25%  { transform: translate(2%,    -1%);     }
+  37%  { transform: translate(-1%,    2.5%);   }
+  50%  { transform: translate(2.5%,   1%);     }
+  62%  { transform: translate(-2%,    1.5%);   }
+  75%  { transform: translate(1%,    -2.5%);   }
+  87%  { transform: translate(-1.5%,  0.5%);   }
+  100% { transform: translate(0,      0);      }
+}
+@keyframes blink {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0.15; }
+}
+
+/* ─── BACKGROUND LAYER CLASSES ─── */
+.bg-breathe {
+  position: fixed;
+  border-radius: 50%;
+  pointer-events: none;
+  z-index: 0;
+  transform-origin: center;
+  transition: opacity 0.5s;
+}
+.bg-gold-glow {
+  width: 80vw; height: 80vw;
+  top: -30vw; left: -15vw;
+  background: radial-gradient(circle, rgba(201,168,76,0.18) 0%, rgba(201,168,76,0.05) 45%, transparent 70%);
+  animation: breathe-gold 11s ease-in-out infinite;
+}
+.bg-blue-glow {
+  width: 65vw; height: 65vw;
+  bottom: -20vw; right: -10vw;
+  background: radial-gradient(circle, rgba(42,109,181,0.2) 0%, rgba(42,109,181,0.05) 45%, transparent 70%);
+  animation: breathe-blue 15s ease-in-out infinite;
+}
+.bg-mid-glow {
+  width: 45vw; height: 45vw;
+  top: 45%; left: 30%;
+  background: radial-gradient(circle, rgba(201,168,76,0.05) 0%, transparent 70%);
+  animation: breathe-mid 19s ease-in-out infinite;
+}
+.bg-grain {
+  position: fixed;
+  inset: -50%;
+  width: 200%; height: 200%;
+  opacity: 0.045;
+  pointer-events: none;
+  z-index: 1;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 512 512' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.75' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+  background-size: 256px 256px;
+  animation: grain-shift 8s steps(8) infinite;
+  transition: opacity 0.5s;
+}
+.bg-vignette {
+  position: fixed;
+  inset: 0;
+  background: radial-gradient(ellipse at 50% 35%, transparent 30%, rgba(0,0,0,0.65) 100%);
+  pointer-events: none;
+  z-index: 1;
+  transition: opacity 0.5s;
+}
+
+/* ─── ORNAMENT DIVIDER ─── */
+.ornament {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 0 32px;
+  opacity: 0.35;
+}
+[data-theme="light"] .ornament { opacity: 0.6; }
+.ornament-line {
+  flex: 1;
+  height: 1px;
+  background: var(--border);
+}
+.ornament-mark {
+  color: var(--gold);
+  font-size: 12px;
+}
+
+/* ─── EYEBROW ─── */
+.eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 14px;
+  font-family: 'Inter', sans-serif;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 5px;
+  text-transform: uppercase;
+  color: var(--gold);
+}
+.eyebrow::before,
+.eyebrow::after {
+  content: '';
+  display: block;
+  width: 28px;
+  height: 1px;
+  background: var(--gold);
+  opacity: 0.6;
+}
+
+/* ─── MASTHEAD RULE (light mode only) ─── */
+.masthead-rule {
+  display: none;
+  position: fixed;
+  top: 0; left: 0;
+  width: 100%;
+  height: 3px;
+  background: var(--text);
+  z-index: 20;
+}
+[data-theme="light"] .masthead-rule { display: block; }
+
+/* ─── THEME TRANSITION ─── */
+*, *::before, *::after {
+  transition: background-color 0.3s, border-color 0.3s, color 0.3s;
+}
+```
+
+- [ ] **Step 2: Verify build passes**
+
+```bash
+cd frontend && npm run build 2>&1 | tail -20
+```
+Expected: build succeeds (may have warnings, no errors).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/app/globals.css
+git commit -m "feat(frontend): add design system tokens, keyframes, and base classes"
+```
+
+---
+
+## Task 2: Layout — Fonts, Theme Init & Masthead Rule
+
+**Files:**
+- Modify: `frontend/src/app/layout.tsx`
+
+- [ ] **Step 1: Read the current layout file**
+
+Read `frontend/src/app/layout.tsx` in full before editing.
+
+- [ ] **Step 2: Replace font imports and add theme infrastructure**
+
+Make these changes to `layout.tsx`:
+
+**a) Replace the Geist font imports** at the top of the file. Remove any `next/font/google` imports for Geist. Replace with:
+
+```tsx
+import { Playfair_Display, Lora, Inter } from 'next/font/google'
+
+const playfair = Playfair_Display({
+  subsets: ['latin'],
+  weight: ['700', '900'],
+  style: ['normal', 'italic'],
+  variable: '--font-playfair',
+  display: 'swap',
+})
+const lora = Lora({
+  subsets: ['latin'],
+  weight: ['400', '500'],
+  style: ['normal', 'italic'],
+  variable: '--font-lora',
+  display: 'swap',
+})
+const inter = Inter({
+  subsets: ['latin'],
+  weight: ['400', '500', '600', '700'],
+  variable: '--font-inter',
+  display: 'swap',
+})
+```
+
+**b) Update the `<html>` tag** — add `data-theme="dark"` as default and include font variables:
+
+```tsx
+<html lang="en" data-theme="dark" className={`${playfair.variable} ${lora.variable} ${inter.variable}`}>
+```
+
+**c) Add theme-init script and masthead rule** as the first children inside `<body>`:
+
+```tsx
+<body>
+  {/* Prevent flash of wrong theme on load */}
+  <script
+    dangerouslySetInnerHTML={{
+      __html: `
+        (function() {
+          var saved = localStorage.getItem('theme') || 'dark';
+          document.documentElement.setAttribute('data-theme', saved);
+        })();
+      `,
+    }}
+  />
+  <div className="masthead-rule" />
+  {children}
+</body>
+```
+
+**d) Update globals.css** to use the font CSS variable — **replace** the existing `body { font-family: ... }` rule written in Task 1 (do not add a second one):
+
+```css
+/* Replace the Task 1 body rule with this: */
+body {
+  font-family: var(--font-inter), Arial, sans-serif;
+}
+```
+
+There should be exactly one `body` block in globals.css. The `next/font` variable `var(--font-inter)` is correct; the literal string `'Inter'` from Task 1 should be removed.
+
+- [ ] **Step 3: Verify build passes**
+
+```bash
+cd frontend && npm run build 2>&1 | tail -20
+```
+Expected: no type errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/app/layout.tsx frontend/src/app/globals.css
+git commit -m "feat(frontend): add Playfair/Lora/Inter fonts and theme-init script"
+```
+
+---
+
+## Task 3: Shared Toggle Component & Theme Hook
+
+**Files:**
+- Create: `frontend/src/components/ui/ThemeToggle.tsx`
+
+The toggle must be usable on any page. Create it once, import it where needed.
+
+- [ ] **Step 1: Create the ThemeToggle component**
+
+Create `frontend/src/components/ui/ThemeToggle.tsx`:
+
+```tsx
+'use client'
+
+import { useEffect, useState } from 'react'
+
+export default function ThemeToggle() {
+  const [theme, setTheme] = useState<'dark' | 'light'>('dark')
+
+  useEffect(() => {
+    const saved = (localStorage.getItem('theme') as 'dark' | 'light') || 'dark'
+    setTheme(saved)
+  }, [])
+
+  const toggle = () => {
+    const next = theme === 'dark' ? 'light' : 'dark'
+    setTheme(next)
+    document.documentElement.setAttribute('data-theme', next)
+    localStorage.setItem('theme', next)
+  }
+
+  return (
+    <button
+      onClick={toggle}
+      style={{
+        position: 'fixed',
+        top: '20px',
+        right: '24px',
+        zIndex: 30,
+        background: 'var(--bg2)',
+        border: '1px solid var(--border)',
+        color: 'var(--text-ui)',
+        fontFamily: 'var(--font-inter), sans-serif',
+        fontSize: '10px',
+        letterSpacing: '2px',
+        textTransform: 'uppercase',
+        padding: '8px 18px',
+        borderRadius: '2px',
+        cursor: 'pointer',
+        transition: 'color 0.2s, border-color 0.2s',
+      }}
+      onMouseEnter={e => {
+        ;(e.target as HTMLButtonElement).style.color = 'var(--gold)'
+        ;(e.target as HTMLButtonElement).style.borderColor = 'var(--gold)'
+      }}
+      onMouseLeave={e => {
+        ;(e.target as HTMLButtonElement).style.color = 'var(--text-ui)'
+        ;(e.target as HTMLButtonElement).style.borderColor = 'var(--border)'
+      }}
+      aria-label={`Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`}
+    >
+      {theme === 'dark' ? '☀' : '☾'} &nbsp; Mode
+    </button>
+  )
+}
+```
+
+- [ ] **Step 2: Verify build**
+
+```bash
+cd frontend && npm run build 2>&1 | tail -10
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/components/ui/ThemeToggle.tsx
+git commit -m "feat(frontend): add ThemeToggle component"
+```
+
+---
+
+## Task 4: Landing Page
+
+**Files:**
+- Modify: `frontend/src/app/page.tsx`
+
+- [ ] **Step 1: Read the current landing page**
+
+Read `frontend/src/app/page.tsx` in full.
+
+- [ ] **Step 2: Rewrite the hero section**
+
+The hero section currently has a dark gradient background, cyan/fuchsia headline, and generic layout. Replace it with the centered editorial hero. Key changes:
+
+**Remove:** All `bg-gradient-to-*`, `from-cyan-*`, `from-fuchsia-*`, `blur-[*]`, `mix-blend-screen`, glassmorphism classes, animated blob divs.
+
+**Add ThemeToggle** at the top of the page JSX (import from `@/components/ui/ThemeToggle`).
+
+**Add background layers** (dark-mode breathing glows) as fixed-position divs at the start of the returned JSX, before main content:
+
+```tsx
+{/* Background layers */}
+<div className="bg-breathe bg-gold-glow" />
+<div className="bg-breathe bg-blue-glow" />
+<div className="bg-breathe bg-mid-glow" />
+<div className="bg-grain" />
+<div className="bg-vignette" />
+```
+
+**Replace the hero headline block** with:
+
+```tsx
+<div style={{ textAlign: 'center', padding: '80px 32px 60px', maxWidth: '740px', margin: '0 auto', position: 'relative', zIndex: 2 }}>
+  <div className="eyebrow" style={{ marginBottom: '28px' }}>DebateMeBro</div>
+  <h1 style={{
+    fontFamily: 'var(--font-playfair), Georgia, serif',
+    fontWeight: 900,
+    fontSize: 'clamp(52px, 9vw, 96px)',
+    lineHeight: 1.0,
+    color: 'var(--text)',
+    letterSpacing: '-2px',
+    marginBottom: '8px',
+  }}>
+    Two minds.
+  </h1>
+  <span style={{
+    display: 'block',
+    fontFamily: 'var(--font-playfair), Georgia, serif',
+    fontSize: 'clamp(26px, 4vw, 44px)',
+    fontWeight: 700,
+    fontStyle: 'italic',
+    color: 'var(--gold)',   /* --gold resolves correctly in both dark and light mode */
+    letterSpacing: '-0.5px',
+    marginBottom: '26px',
+  }}>
+    One argument.
+  </span>
+  <p style={{
+    fontFamily: 'var(--font-lora), Georgia, serif',
+    fontSize: '18px',
+    fontWeight: 400,
+    lineHeight: 1.8,
+    color: 'var(--text-ui)',
+    maxWidth: '460px',
+    margin: '0 auto 36px',
+  }}>
+    Watch two AI agents argue the greatest questions of our time — then decide who made the stronger case.
+  </p>
+  {/* Keep existing CTA buttons but update colors — see Step 3 */}
+</div>
+```
+
+- [ ] **Step 3: Update CTA button colors**
+
+Find the primary CTA button(s). Replace `from-cyan-500 to-blue-600` gradient classes and any `shadow-[*cyan*]` glow with:
+
+```tsx
+style={{
+  background: 'var(--gold)',
+  color: '#0c0c10',
+  fontFamily: 'var(--font-inter), sans-serif',
+  fontWeight: 700,
+  letterSpacing: '1px',
+  border: 'none',
+  padding: '14px 32px',
+  borderRadius: '2px',
+  cursor: 'pointer',
+  fontSize: '14px',
+}}
+```
+
+Secondary/ghost buttons: `background: transparent`, `border: 1px solid var(--border)`, `color: var(--text)`.
+
+- [ ] **Step 4: Add ornament divider**
+
+Between the hero and the next section (feature cards / debate list), add:
+
+```tsx
+<div className="ornament" style={{ margin: '0 0 40px' }}>
+  <div className="ornament-line" />
+  <span className="ornament-mark">✦</span>
+  <div className="ornament-line" />
+</div>
+```
+
+- [ ] **Step 5: Replace remaining cyan/fuchsia/purple colors**
+
+Search the file for any remaining `text-cyan-*`, `text-fuchsia-*`, `text-purple-*`, `bg-cyan-*`, `bg-fuchsia-*`, `border-cyan-*`, `border-fuchsia-*` classes. Replace with token equivalents:
+- Cyan → `var(--gold)` or `var(--blue-lt)`
+- Fuchsia/purple → `var(--blue)` or `var(--text-ui)`
+- `text-white` in body copy → `var(--text)`
+- `text-gray-400` → `var(--text-ui)`
+
+- [ ] **Step 6: Verify build and lint**
+
+```bash
+cd frontend && npm run build 2>&1 | tail -20 && npm run lint 2>&1 | tail -10
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add frontend/src/app/page.tsx
+git commit -m "feat(frontend): redesign landing page with Ink/Gold/Sapphire system"
+```
+
+---
+
+## Task 5: Argument Card Component
+
+**Files:**
+- Modify: `frontend/src/components/debate/ArgumentCard.tsx`
+
+This is the most-read component. Get it right.
+
+- [ ] **Step 1: Read the current component**
+
+Read `frontend/src/components/debate/ArgumentCard.tsx` in full.
+
+- [ ] **Step 2: Update card structure and styling**
+
+The card receives a `side` prop (`'pro' | 'con'`). Apply these styles:
+
+**Card wrapper:**
+```tsx
+style={{
+  borderRadius: '2px',
+  border: '1px solid var(--border-dim)',
+  borderLeft: `3px solid ${side === 'pro' ? 'var(--gold)' : 'var(--blue)'}`,
+  overflow: 'hidden',
+  transition: 'border-color 0.25s',
+  marginBottom: '14px',
+}}
+```
+
+**Card header** (contains avatar + name + phase label):
+```tsx
+style={{
+  padding: '14px 18px 12px',
+  display: 'flex',
+  alignItems: 'center',
+  gap: '12px',
+  borderBottom: '1px solid var(--border-dim)',
+  background: side === 'pro' ? 'rgba(201,168,76,0.05)' : 'rgba(42,109,181,0.05)',
+}}
+```
+
+**Avatar** (circular initial):
+```tsx
+style={{
+  width: '34px',
+  height: '34px',
+  borderRadius: '50%',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  fontFamily: 'var(--font-playfair), Georgia, serif',
+  fontSize: '15px',
+  fontWeight: 900,
+  flexShrink: 0,
+  background: side === 'pro' ? 'var(--gold-dim)' : 'var(--blue-dim)',
+  color: side === 'pro' ? 'var(--gold-lt)' : 'var(--blue-lt)',
+  border: side === 'pro' ? '1px solid var(--border)' : '1px solid rgba(42,109,181,0.3)',
+}}
+```
+
+The avatar initial is the first character of the persona name (e.g., `name[0].toUpperCase()`).
+
+**Persona name:**
+```tsx
+style={{
+  fontFamily: 'var(--font-playfair), Georgia, serif',
+  fontSize: '14px',
+  fontWeight: 700,
+  color: 'var(--text)',
+}}
+```
+
+**Phase label:**
+```tsx
+style={{
+  fontFamily: 'var(--font-inter), sans-serif',
+  fontSize: '9px',
+  fontWeight: 600,
+  letterSpacing: '2px',
+  textTransform: 'uppercase',
+  color: side === 'pro' ? 'var(--gold)' : 'var(--blue-lt)',
+  marginTop: '2px',
+}}
+```
+
+**Card body:**
+```tsx
+style={{
+  padding: '18px 20px 20px',
+  background: 'var(--bg2)',
+}}
+```
+
+**Body text — the primary reading surface:**
+```tsx
+style={{
+  fontFamily: 'var(--font-lora), Georgia, serif',
+  fontSize: '16px',
+  lineHeight: 1.85,
+  color: 'var(--text-2)',
+  fontWeight: 400,
+  letterSpacing: '0.01em',
+}}
+```
+
+Remove all old `text-cyan-*`, `text-fuchsia-*`, `bg-slate-*`, `backdrop-blur-*`, `border-cyan-*` Tailwind classes.
+
+- [ ] **Step 3: Verify build**
+
+```bash
+cd frontend && npm run build 2>&1 | tail -20
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/components/debate/ArgumentCard.tsx
+git commit -m "feat(frontend): redesign ArgumentCard with Lora body text and gold/blue system"
+```
+
+---
+
+## Task 6: Phase Navigation Component
+
+**Files:**
+- Modify: `frontend/src/components/debate/PhaseNav.tsx`
+
+- [ ] **Step 1: Read the current component**
+
+Read `frontend/src/components/debate/PhaseNav.tsx` in full.
+
+- [ ] **Step 2: Update phase nav styling**
+
+**Nav container:**
+```tsx
+style={{
+  display: 'flex',
+  gap: '2px',
+  width: '100%',
+}}
+```
+
+**Each phase tab** (receives `status: 'done' | 'active' | 'pending'`):
+```tsx
+style={{
+  flex: 1,
+  padding: '11px 4px',
+  textAlign: 'center',
+  fontFamily: 'var(--font-inter), sans-serif',
+  fontSize: '9px',
+  fontWeight: 600,
+  letterSpacing: '2px',
+  textTransform: 'uppercase',
+  background: status === 'active' ? 'var(--bg3)' : 'var(--bg2)',
+  color: status === 'active' ? 'var(--gold)' : 'var(--text-ui)',
+  borderBottom: status === 'active'
+    ? '2px solid var(--gold)'
+    : status === 'done'
+    ? '2px solid var(--border-dim)'
+    : '2px solid transparent',
+  transition: 'all 0.2s',
+}}
+```
+
+**Completed phase checkmark/indicator:** Replace `text-cyan-300` with `color: 'var(--gold)'`.
+
+Remove all `text-cyan-*`, `text-fuchsia-*`, `bg-slate-*` classes.
+
+- [ ] **Step 3: Verify build**
+
+```bash
+cd frontend && npm run build 2>&1 | tail -10
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/components/debate/PhaseNav.tsx
+git commit -m "feat(frontend): redesign PhaseNav with gold active state"
+```
+
+---
+
+## Task 7: StreamingText, CitationBadge & StrategicAnalysisPanel
+
+**Files:**
+- Modify: `frontend/src/components/debate/StreamingText.tsx`
+- Modify: `frontend/src/components/debate/CitationBadge.tsx`
+- Modify: `frontend/src/components/debate/StrategicAnalysisPanel.tsx`
+
+- [ ] **Step 1: Read all three components**
+
+Read each file in full before editing.
+
+- [ ] **Step 2: Update StreamingText**
+
+In `StreamingText.tsx`:
+- Find the streaming cursor element. Replace `bg-cyan-400` (pro) / `bg-fuchsia-400` (con) with:
+  - Pro cursor: `background: 'var(--gold)'`
+  - Con cursor: `background: 'var(--blue-lt)'`
+  - If cursor uses a single class without side awareness, check how `side` prop is passed; use it to conditionally apply the token.
+- Find any `font-bold text-white` on `<strong>` elements inside rendered markdown. Replace `text-white` with `color: 'var(--text)'`.
+- Remove any `text-cyan-*`, `text-fuchsia-*` classes.
+
+- [ ] **Step 3: Update CitationBadge**
+
+In `CitationBadge.tsx`:
+- Badge button: replace cyan classes with:
+  ```tsx
+  style={{
+    background: 'var(--gold-dim)',
+    border: '1px solid var(--border)',
+    color: 'var(--gold-lt)',
+    borderRadius: '3px',
+    padding: '1px 6px',
+    fontSize: '11px',
+    cursor: 'pointer',
+  }}
+  ```
+- Popup tooltip container: `background: 'var(--bg3)'`, `border: '1px solid var(--border)'`, `color: 'var(--text)'`
+- "🌐 Verified Source" label: `color: 'var(--text-ui)'`, Inter font.
+
+- [ ] **Step 4: Update StrategicAnalysisPanel**
+
+In `StrategicAnalysisPanel.tsx`:
+- Pro panel accent: replace `border-cyan-*`, `bg-cyan-*`, `text-cyan-*` with:
+  - border: `var(--gold)`
+  - background fill: `var(--gold-dim)`
+  - text: `var(--gold-lt)`
+- Con panel accent: replace `border-fuchsia-*`, `bg-fuchsia-*`, `text-fuchsia-*` with:
+  - border: `var(--blue)`
+  - background fill: `var(--blue-dim)`
+  - text: `var(--blue-lt)`
+
+- [ ] **Step 5: Verify build**
+
+```bash
+cd frontend && npm run build 2>&1 | tail -20
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/components/debate/StreamingText.tsx \
+        frontend/src/components/debate/CitationBadge.tsx \
+        frontend/src/components/debate/StrategicAnalysisPanel.tsx
+git commit -m "feat(frontend): update streaming, citation, and analysis panel colors"
+```
+
+---
+
+## Task 8: Debate View Page
+
+**Files:**
+- Modify: `frontend/src/app/debates/[id]/page.tsx`
+
+This is the main debate experience page. It contains the debate header, score row, and split-screen layout.
+
+- [ ] **Step 1: Read the current page**
+
+Read `frontend/src/app/debates/[id]/page.tsx` in full.
+
+- [ ] **Step 2: Add background layers and ThemeToggle**
+
+Import `ThemeToggle` from `@/components/ui/ThemeToggle`. At the top of the returned JSX (before main content wrapper):
+
+```tsx
+<ThemeToggle />
+<div className="bg-breathe bg-gold-glow" />
+<div className="bg-breathe bg-blue-glow" />
+<div className="bg-breathe bg-mid-glow" />
+<div className="bg-grain" />
+<div className="bg-vignette" />
+```
+
+All content below must have `position: relative; z-index: 2` to sit above the background.
+
+- [ ] **Step 3: Update debate header card**
+
+Find the topic/motion title block. Apply:
+```tsx
+// Motion header card wrapper
+style={{
+  background: 'var(--bg2)',
+  border: '1px solid var(--border-dim)',
+  borderTop: '2px solid var(--gold)',
+  padding: '24px 28px 20px',
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'flex-start',
+  gap: '20px',
+}}
+
+// "Motion Before the House" eyebrow
+style={{
+  fontFamily: 'var(--font-inter), sans-serif',
+  fontSize: '10px',
+  fontWeight: 700,
+  letterSpacing: '4px',
+  textTransform: 'uppercase',
+  color: 'var(--gold)',
+  marginBottom: '8px',
+}}
+
+// Motion title
+style={{
+  fontFamily: 'var(--font-playfair), Georgia, serif',
+  fontSize: '22px',
+  fontWeight: 700,
+  color: 'var(--text)',
+  lineHeight: 1.25,
+}}
+
+// Live badge
+style={{
+  background: 'var(--gold-dim)',
+  border: '1px solid var(--border)',
+  color: 'var(--gold)',
+  fontFamily: 'var(--font-inter), sans-serif',
+  fontSize: '10px',
+  fontWeight: 700,
+  letterSpacing: '2px',
+  textTransform: 'uppercase',
+  padding: '6px 14px',
+  borderRadius: '2px',
+  display: 'flex',
+  alignItems: 'center',
+  gap: '6px',
+}}
+```
+
+Add a blinking dot inside the live badge: `<span style={{ width: '6px', height: '6px', background: 'var(--gold)', borderRadius: '50%', animation: 'blink 1.4s ease-in-out infinite', display: 'inline-block' }} />`.
+
+- [ ] **Step 4: Update score row**
+
+Find the Pro/Con score display below the header. Apply:
+
+```tsx
+// Score row grid
+style={{
+  display: 'grid',
+  gridTemplateColumns: '1fr 1px 1fr',
+  background: 'var(--bg3)',
+  border: '1px solid var(--border-dim)',
+  borderTop: 'none',
+  marginBottom: '32px',
+}}
+
+// Pro side
+style={{ padding: '16px 26px' }}
+// Badge: Inter 9px 700, color: 'var(--gold)'
+// Name: Playfair 700 16px, color: 'var(--text)'
+// Role: Lora italic 13px, color: 'var(--text-ui)'
+// Score number: Playfair 900 34px, color: 'var(--gold-lt)'
+
+// Con side — right-aligned (textAlign: 'right')
+// Badge: color: 'var(--blue-lt)'
+// Score number: color: 'var(--blue-lt)'
+```
+
+The divider column: `background: 'var(--border-dim)'`.
+
+- [ ] **Step 5: Update split-screen column headers**
+
+The two column labels above the argument cards:
+```tsx
+// Pro column label
+style={{
+  fontFamily: 'var(--font-inter), sans-serif',
+  fontSize: '10px',
+  fontWeight: 700,
+  letterSpacing: '4px',
+  textTransform: 'uppercase',
+  color: 'var(--gold)',
+  paddingBottom: '10px',
+  borderBottom: '2px solid var(--gold)',
+}}
+
+// Con column label
+style={{
+  // same as above but:
+  color: 'var(--blue-lt)',
+  borderBottom: '2px solid var(--blue)',
+}}
+```
+
+- [ ] **Step 6: Update judging results section**
+
+Find any `ScoreBar`, judge cards, or judging result displays. Replace:
+- `bg-cyan-*` / `text-cyan-*` → gold tokens
+- `bg-fuchsia-*` / `text-fuchsia-*` → blue tokens
+- Progress bars: Pro bar `background: 'var(--gold)'`, Con bar `background: 'var(--blue-lt)'`
+
+- [ ] **Step 7: Replace all remaining legacy colors**
+
+Scan the file for any remaining `slate-`, `cyan-`, `fuchsia-`, `purple-` Tailwind classes and convert to token equivalents.
+
+- [ ] **Step 8: Verify build**
+
+```bash
+cd frontend && npm run build 2>&1 | tail -20
+```
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add "frontend/src/app/debates/[id]/page.tsx"
+git commit -m "feat(frontend): redesign debate view page with new design system"
+```
+
+---
+
+## Task 9: History Card & Dashboard
+
+**Files:**
+- Modify: `frontend/src/components/dashboard/HistoryCard.tsx`
+- Modify: `frontend/src/app/dashboard/page.tsx`
+
+- [ ] **Step 1: Read both files**
+
+Read `frontend/src/components/dashboard/HistoryCard.tsx` and `frontend/src/app/dashboard/page.tsx` in full.
+
+- [ ] **Step 2: Update HistoryCard**
+
+- **Winner badge:** Replace cyan/fuchsia classes with:
+  - Pro wins: `background: 'var(--gold-dim)'`, `color: 'var(--gold-lt)'`, `border: '1px solid var(--border)'`
+  - Con wins: `background: 'var(--blue-dim)'`, `color: 'var(--blue-lt)'`, `border: '1px solid rgba(42,109,181,0.25)'`
+- **Score dots:** Pro dot `background: 'var(--gold)'`, Con dot `background: 'var(--blue-lt)'`
+- **Topic title:** Add `fontFamily: 'var(--font-playfair), Georgia, serif'`, `fontWeight: 700`
+- **Card border hover:** `border: '1px solid var(--border-dim)'`, hover → `var(--border)`
+- **Card background:** `background: 'var(--bg2)'`
+
+- [ ] **Step 3: Update dashboard page**
+
+Replace any remaining legacy colors with token equivalents. Add `ThemeToggle` if not already present on a parent layout.
+
+- [ ] **Step 4: Verify build**
+
+```bash
+cd frontend && npm run build 2>&1 | tail -10
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/dashboard/HistoryCard.tsx frontend/src/app/dashboard/page.tsx
+git commit -m "feat(frontend): redesign history card and dashboard page"
+```
+
+---
+
+## Task 10: Remaining Pages — Browse, Auth, New Debate
+
+**Files:**
+- Modify: `frontend/src/app/browse/page.tsx`
+- Modify: `frontend/src/app/auth/page.tsx`
+- Modify: `frontend/src/app/debates/new/page.tsx`
+
+- [ ] **Step 1: Read all three files**
+
+Read each in full before editing.
+
+- [ ] **Step 2: Apply token-based styling to Browse page**
+
+In `browse/page.tsx`:
+- Add `ThemeToggle` import and render it.
+- Add background layers (same pattern as landing page).
+- Replace all `slate-*`, `cyan-*`, `fuchsia-*` color classes with token equivalents.
+- Heading: Playfair Display, `color: 'var(--text)'`
+- Cards: `background: 'var(--bg2)'`, `border: '1px solid var(--border-dim)'`
+- Sort tabs / filters: Inter font, gold for active state
+
+- [ ] **Step 3: Apply token-based styling to Auth page**
+
+In `auth/page.tsx`:
+- Add `ThemeToggle`.
+- Replace all legacy color classes.
+- Form inputs: `background: 'var(--bg2)'`, `border: '1px solid var(--border-dim)'`, `color: 'var(--text)'`
+- Input focus ring: `outline: '2px solid var(--gold)'`
+- Submit button: gold background (same style as landing CTA)
+- Error text: keep red but update to `color: '#ef4444'` (explicit, not Tailwind class)
+
+- [ ] **Step 4: Apply token-based styling to New Debate page**
+
+In `debates/new/page.tsx`:
+- Add `ThemeToggle`.
+- Replace all legacy color classes.
+- Wizard step indicators: active step `color: 'var(--gold)'`, completed `var(--text-ui)`, pending `var(--border-dim)`
+- Step heading: Playfair Display 700
+- Upload area / textarea borders: `var(--border-dim)` → hover `var(--border)`
+- Action buttons: gold primary, neutral secondary
+
+- [ ] **Step 5: Verify build and lint**
+
+```bash
+cd frontend && npm run build 2>&1 | tail -20 && npm run lint 2>&1 | tail -10
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/app/browse/page.tsx \
+        frontend/src/app/auth/page.tsx \
+        "frontend/src/app/debates/new/page.tsx"
+git commit -m "feat(frontend): apply design system to browse, auth, and new debate pages"
+```
+
+---
+
+## Task 11: Fix Jest Snapshots & Final Verification
+
+**Files:**
+- Modify: `frontend/tests/components/Home.test.tsx` (if snapshot fails)
+- Modify: `frontend/tests/components/Dashboard.test.tsx` (if snapshot fails)
+
+- [ ] **Step 1: Run the Jest test suite**
+
+```bash
+cd frontend && npm test -- --watchAll=false 2>&1 | tail -30
+```
+
+- [ ] **Step 2: Update snapshots if needed**
+
+If any snapshot tests fail due to the styling changes (expected — the HTML structure changed):
+
+```bash
+cd frontend && npm test -- --watchAll=false --updateSnapshot 2>&1 | tail -20
+```
+
+Review the diff output to confirm the snapshot changes are expected (styling changes only, no structural regressions).
+
+- [ ] **Step 3: Run full build + lint one final time**
+
+```bash
+cd frontend && npm run build 2>&1 | tail -20 && npm run lint 2>&1 | tail -10
+```
+Expected: zero errors.
+
+- [ ] **Step 4: Add `.superpowers/` to `.gitignore` if not already present**
+
+```bash
+grep -q '.superpowers' /mnt/c/Users/Jason\ Ingersoll/dev/Debate-me-bro/.gitignore \
+  || echo '.superpowers/' >> /mnt/c/Users/Jason\ Ingersoll/dev/Debate-me-bro/.gitignore
+```
+
+- [ ] **Step 5: Final commit**
+
+```bash
+git add frontend/tests/ .gitignore
+git commit -m "chore(frontend): update snapshots for UI redesign; add .superpowers to gitignore"
+```
+
+---
+
+## Verification Checklist (Manual)
+
+After all tasks are complete, visually verify the following in a browser (`npm run dev`):
+
+- [ ] Dark mode loads by default on first visit (no flash of light mode)
+- [ ] Light mode toggle switches correctly and persists on refresh
+- [ ] Landing page: centered hero, "Two minds." in large Playfair, "One argument." in italic gold
+- [ ] Background breathing animations visible in dark mode, gone in light mode
+- [ ] Masthead rule (3px black line) appears at top in light mode only
+- [ ] Debate page: gold top-border on debate header, gold/blue score numbers
+- [ ] Pro arguments: gold left-border, gold labels
+- [ ] Con arguments: blue left-border, blue labels
+- [ ] Argument body text is Lora serif, visibly larger and more readable than before
+- [ ] Light mode argument cards: white background, near-black body text
+- [ ] Citation badges: gold tones (no cyan)
+- [ ] Phase nav: gold active underline
+- [ ] Dashboard history cards: gold/blue winner badges

--- a/Docs/superpowers/specs/2026-03-24-ui-redesign-design.md
+++ b/Docs/superpowers/specs/2026-03-24-ui-redesign-design.md
@@ -20,151 +20,277 @@ Replace the generic "vibe-coded" aesthetic (cyan/fuchsia gradients, glassmorphis
 
 ---
 
+## Dark / Light Mode Toggle
+
+**Default:** Dark mode.
+
+**Mechanism:** A `data-theme` attribute on `<html>`, toggled by a button, persisted to `localStorage`.
+
+```ts
+// On mount — read saved preference or default to dark
+const saved = localStorage.getItem('theme') ?? 'dark'
+document.documentElement.setAttribute('data-theme', saved)
+
+// On toggle
+const next = current === 'dark' ? 'light' : 'dark'
+document.documentElement.setAttribute('data-theme', next)
+localStorage.setItem('theme', next)
+```
+
+**CSS selector pattern:** All tokens are defined under `[data-theme="dark"]` and `[data-theme="light"]` (not `@media (prefers-color-scheme)`). The current `globals.css` media query block is replaced by these attribute selectors. Remove the Tailwind `dark:` class strategy — all theming happens via CSS custom properties only.
+
+**Toggle widget:** Fixed top-right. Inter 11px uppercase. `☀ / ☾` label. Hover: gold text and border. Background `var(--bg2)`, border `var(--border)`.
+
+---
+
 ## Color System
 
-### Dark Mode (default)
+### Token Definitions
+
+All tokens must be defined under both `[data-theme="dark"]` and `[data-theme="light"]`.
+
+#### Dark Mode (`[data-theme="dark"]`)
 
 | Token | Value | Usage |
 |-------|-------|-------|
 | `--bg` | `#0c0c10` | Page background |
-| `--bg2` | `#13131a` | Card/panel backgrounds |
-| `--bg3` | `#1c1c26` | Elevated surfaces, phase nav active |
-| `--gold` | `#c9a84c` | Pro side, primary actions, accents |
-| `--gold-lt` | `#e8c97a` | Pro scores, hero italic, hover states |
-| `--gold-dim` | `rgba(201,168,76,0.13)` | Avatar backgrounds, subtle fills |
-| `--blue` | `#2a6db5` | Con side border, structural accents |
+| `--bg2` | `#13131a` | Card / panel backgrounds, argument card bodies |
+| `--bg3` | `#1c1c26` | Elevated surfaces, phase nav active state |
+| `--gold` | `#c9a84c` | Pro side borders, primary CTA text/border |
+| `--gold-lt` | `#e8c97a` | Pro scores, hero italic line, hover states |
+| `--gold-dim` | `rgba(201,168,76,0.13)` | Pro avatar fill background |
+| `--blue` | `#2a6db5` | Con side borders |
 | `--blue-lt` | `#5a9fe0` | Con labels, scores, hover states |
-| `--blue-dim` | `rgba(42,109,181,0.13)` | Avatar backgrounds |
-| `--text` | `#f2ead6` | Primary text (headings, names) |
-| `--text-2` | `#d4c9ae` | Argument body text — high contrast reading |
-| `--text-ui` | `#8a7a60` | Labels, meta, dim UI chrome |
-| `--border` | `rgba(201,168,76,0.2)` | Visible borders |
+| `--blue-dim` | `rgba(42,109,181,0.13)` | Con avatar fill background |
+| `--text` | `#f2ead6` | Primary text: headings, debate titles, names |
+| `--text-2` | `#d4c9ae` | Argument body text — highest reading contrast |
+| `--text-ui` | `#8a7a60` | Labels, meta, phase nav, eyebrows |
+| `--border` | `rgba(255,255,255,0.1)` | Neutral structural borders (dividers, card outlines) |
 | `--border-dim` | `rgba(255,255,255,0.07)` | Subtle structural dividers |
 
-### Light Mode (user-toggled)
+> **Note on card borders:** Pro card left-borders use `--gold` directly. Con card left-borders use `--blue` directly. `--border` and `--border-dim` are neutral structural tokens only (card outlines, dividers, score row lines). Never use `--border` for the colored accent border on argument cards.
+
+#### Light Mode (`[data-theme="light"]`)
 
 | Token | Value | Usage |
 |-------|-------|-------|
 | `--bg` | `#ffffff` | Clean white page |
 | `--bg2` | `#f7f7f5` | Card surface |
 | `--bg3` | `#eeeeea` | Elevated surfaces |
-| `--gold` | `#8a5e0a` | Pro accents (deep amber for legibility) |
+| `--gold` | `#8a5e0a` | Pro accents — deep amber for legibility on white |
 | `--gold-lt` | `#a87214` | Pro scores |
-| `--blue` | `#0f4080` | Con accents (deep navy) |
+| `--gold-dim` | `rgba(138,94,10,0.08)` | Pro avatar fill background |
+| `--blue` | `#0f4080` | Con accents — deep navy |
 | `--blue-lt` | `#1a5aa8` | Con scores |
+| `--blue-dim` | `rgba(15,64,128,0.08)` | Con avatar fill background |
 | `--text` | `#0a0a0a` | Near-black primary text |
-| `--text-2` | `#1a1a1a` | Argument body — near-black |
-| `--text-ui` | `#767676` | Labels and meta |
-| `--border` | `rgba(0,0,0,0.15)` | Visible borders |
-| `--border-dim` | `rgba(0,0,0,0.08)` | Subtle dividers |
+| `--text-2` | `#1a1a1a` | Argument body text — near-black |
+| `--text-ui` | `#767676` | Labels, meta |
+| `--border` | `rgba(0,0,0,0.15)` | Neutral structural borders |
+| `--border-dim` | `rgba(0,0,0,0.08)` | Subtle structural dividers |
 
 **Light mode specifics:**
-- All background animations disabled (breathe glows, grain, vignette → opacity 0)
-- A 3px solid black masthead rule appears at the very top of the page
-- Argument card bodies use pure `#ffffff` for maximum reading contrast
-- No warm parchment tones — clean newspaper white throughout
+- All background animations disabled: `[data-theme="light"] .bg-gold, .bg-blue, .bg-mid, .bg-grain, .bg-vignette { opacity: 0; pointer-events: none; }`
+- A 3px solid `var(--text)` masthead rule rendered as a `<div class="masthead-rule">` at the top of `layout.tsx`, hidden in dark mode. Full viewport width. Fixed position, `z-index: 20`.
+- Argument card bodies: `background: #ffffff` (overrides `--bg2`) for maximum reading contrast.
 
 ---
 
 ## Typography
 
-Three-tier system. Each tier has a single job.
+Three-tier system. Each font has a single job.
 
 | Font | Role | Usage |
 |------|------|-------|
-| **Playfair Display** | Drama & identity | Page headlines, debate titles, persona names, scores |
-| **Lora** | Reading comfort | Argument body text, hero subtitle, persona roles |
-| **Inter** | UI chrome | Phase nav, labels, badges, eyebrows, buttons |
+| **Playfair Display** | Drama & identity | Page headlines, debate titles, persona names, score numbers, avatar initials |
+| **Lora** | Reading comfort | Argument body text, hero subtitle paragraph, persona role lines |
+| **Inter** | UI chrome | Phase nav, labels, badges, eyebrows, buttons, toggle, section labels |
 
-**Sizes (base 16px):**
-- Hero h1: `clamp(52px, 9vw, 96px)`, weight 900, tracking -2px
-- Hero italic sub-line: `clamp(26px, 4vw, 44px)`, Playfair italic 700, color `--gold-lt`
-- Hero body: 18px Lora 400
-- Debate title: 22px Playfair 700
-- Persona name: 16px Playfair 700
-- Score number: 34px Playfair 900
-- Argument body text: **16px Lora 400, line-height 1.85** — this is the primary reading surface
-- Section labels / eyebrows: 10px Inter 700, letter-spacing 4px, uppercase
-- Phase nav: 9px Inter 600, letter-spacing 2px, uppercase
+**Load via Google Fonts in `layout.tsx`:**
+```
+Playfair+Display:ital,wght@0,700;0,900;1,700
+Lora:ital,wght@0,400;0,500;1,400
+Inter:wght@400;500;600;700
+```
+Remove Geist Sans and Geist Mono imports entirely.
+
+**Type scale:**
+
+| Element | Font | Size | Weight | Notes |
+|---------|------|------|--------|-------|
+| Hero h1 | Playfair Display | `clamp(52px, 9vw, 96px)` | 900 | tracking -2px |
+| Hero italic sub-line | Playfair Display italic | `clamp(26px, 4vw, 44px)` | 700 | color `--gold-lt` (dark) / `--gold` (light) |
+| Hero body paragraph | Lora | 18px | 400 | color `--text-ui`, line-height 1.8 |
+| Debate / motion title | Playfair Display | 22px | 700 | color `--text` |
+| Persona name | Playfair Display | 16px | 700 | color `--text` |
+| Persona role / subtitle | Lora italic | 13px | 400 | color `--text-ui` |
+| Score number | Playfair Display | 34px | 900 | Pro: `--gold-lt` / Con: `--blue-lt` |
+| **Argument body text** | **Lora** | **16px** | **400** | **color `--text-2`, line-height 1.85, letter-spacing 0.01em** |
+| Bold within argument text | Lora | 16px | 700 | color `--text` (one step brighter than body) |
+| Section eyebrow | Inter | 10px | 700 | letter-spacing 4px, uppercase, color `--gold` |
+| Section label | Inter | 10px | 700 | letter-spacing 4px, uppercase, color `--text-ui` |
+| Phase nav | Inter | 9px | 600 | letter-spacing 2px, uppercase |
+| Avatar initial | Playfair Display | 15px | 900 | |
+| UI labels / badges | Inter | 9–11px | 600–700 | letter-spacing 2–3px, uppercase |
 
 ---
 
 ## Background System (dark mode only)
 
-Three independent breathing radial glows + animated film grain + vignette. All disabled in light mode.
+### Keyframe Animations
 
-### Glow layers
-1. **Gold glow** — `80vw` circle, top-left, `rgba(201,168,76,0.18)` core fading to transparent. Animates: scale 1→1.2→0.9, drifts slightly, period 11s.
-2. **Blue glow** — `65vw` circle, bottom-right, `rgba(42,109,181,0.2)` core. Animates: scale 1→1.25→0.85, opposite drift, period 15s.
-3. **Mid glow** — `45vw` circle, center-page, faint gold. Animates: scale 1→1.35, period 19s.
+```css
+@keyframes breathe-gold {
+  0%, 100% { transform: scale(1) translate(0, 0);           opacity: 0.8; }
+  33%       { transform: scale(1.2) translate(1.5vw, 1vw);  opacity: 1;   }
+  66%       { transform: scale(0.9) translate(-1vw, -0.5vw); opacity: 0.5; }
+}
+@keyframes breathe-blue {
+  0%, 100% { transform: scale(1) translate(0, 0);            opacity: 0.7; }
+  40%       { transform: scale(1.25) translate(-1.5vw, 1vw); opacity: 1;   }
+  70%       { transform: scale(0.85) translate(1vw, -1.5vw); opacity: 0.4; }
+}
+@keyframes breathe-mid {
+  0%, 100% { transform: scale(1);    opacity: 0.35; }
+  50%       { transform: scale(1.35); opacity: 0.7;  }
+}
+@keyframes grain-shift {
+  0%   { transform: translate(0, 0); }
+  12%  { transform: translate(-1.5%, -2%); }
+  25%  { transform: translate(2%, -1%); }
+  37%  { transform: translate(-1%, 2.5%); }
+  50%  { transform: translate(2.5%, 1%); }
+  62%  { transform: translate(-2%, 1.5%); }
+  75%  { transform: translate(1%, -2.5%); }
+  87%  { transform: translate(-1.5%, 0.5%); }
+  100% { transform: translate(0, 0); }
+}
+```
 
-Each layer uses independent timing so they never sync — creates a continuously shifting, non-repetitive breathing effect.
+### Layer Specs
 
-### Film grain
-SVG `feTurbulence` fractalNoise texture, `opacity: 0.045`, shifts position in 8-step increments every 8s. Adds texture without pattern repetition.
+| Layer | Size | Position | Color | Animation | Period | Easing |
+|-------|------|----------|-------|-----------|--------|--------|
+| Gold glow | `80vw × 80vw` | top `-30vw`, left `-15vw` | `rgba(201,168,76,0.18)` core → transparent | `breathe-gold` | 11s | `ease-in-out` |
+| Blue glow | `65vw × 65vw` | bottom `-20vw`, right `-10vw` | `rgba(42,109,181,0.2)` core → transparent | `breathe-blue` | 15s | `ease-in-out` |
+| Mid glow | `45vw × 45vw` | top `45%`, left `30%` | `rgba(201,168,76,0.05)` core → transparent | `breathe-mid` | 19s | `ease-in-out` |
+| Film grain | `200% × 200%` (inset `-50%`) | fixed, inset `-50%` | SVG feTurbulence fractalNoise, `opacity: 0.045` | `grain-shift` steps(8) | 8s | `steps(8)` |
+| Vignette | full viewport | fixed inset 0 | `radial-gradient(ellipse at 50% 35%, transparent 30%, rgba(0,0,0,0.65) 100%)` | none | — | — |
 
-### Vignette
-`radial-gradient` from transparent center to `rgba(0,0,0,0.65)` edges. Focuses the eye to center content, adds depth.
+All layers: `position: fixed`, `pointer-events: none`, `border-radius: 50%` (glows only), `transform-origin: center`.
+
+Grain layer uses a `200% × 200%` wrapper div positioned at `inset: -50%` so edge-shifting doesn't reveal blank space. `animation-timing-function: steps(8)` — not smooth, discrete jumps every frame interval.
 
 ---
 
 ## Component Styling
 
+### Ornament Divider
+
+A new inline JSX element (not a separate component file) used in `page.tsx` and `debates/[id]/page.tsx`:
+
+```tsx
+<div className="ornament">
+  <div className="ornament-line" />
+  <span className="ornament-mark">✦</span>
+  <div className="ornament-line" />
+</div>
+```
+
+CSS: flex row, `gap: 14px`, lines are `flex: 1; height: 1px; background: var(--border)`. Mark is `color: var(--gold); font-size: 12px`. Whole element `opacity: 0.35` dark / `opacity: 0.6` light.
+
+### Eyebrow
+
+```tsx
+<div className="eyebrow">DebateMeBro</div>
+```
+
+Inter 11px 700, letter-spacing 5px, uppercase, `color: var(--gold)`. Flanked by decorative lines via `::before` / `::after` pseudo-elements: `width: 28px; height: 1px; background: var(--gold); opacity: 0.6`.
+
 ### Hero Section
-- Centered layout (text-align: center)
-- Eyebrow: Inter uppercase with decorative line flanks (`::before` / `::after`)
-- H1 "Two minds." — massive Playfair 900
-- Italic gold sub-line "One argument." — Playfair italic, gold, visually subordinate but present
-- Body: Lora 400, muted color (`--text-ui`)
+- Centered (`text-align: center`), max-width 740px, `margin: 0 auto`
+- H1 "Two minds." — Playfair 900, massive, near-black tracking
+- Italic gold sub-line "One argument." — Playfair italic 700, `--gold-lt` dark / `--gold` light
+- Body: Lora 400 18px, `--text-ui` color
 
 ### Phase Navigation
-- Horizontal tab bar, full width
-- Active phase: gold underline (2px), `--bg3` background, gold text
-- Completed phases: dim underline, muted text
-- Pending phases: no underline, dim text
-- Inter 9px uppercase throughout
+- Horizontal tab bar, full width, `gap: 2px` between tabs
+- Done: dim underline `--border-dim`, muted text
+- Active: `border-bottom: 2px solid var(--gold)`, `--bg3` background, gold text
+- Pending: no underline, `--text-ui` text
+- Inter 9px 600 uppercase throughout
+- Light mode: each tab gets `border: 1px solid var(--border-dim)` outline
 
 ### Debate Header Card
-- `--bg2` background, `border-top: 2px solid var(--gold)` (3px in light mode)
-- "Motion Before the House" eyebrow in gold
-- Debate title in Playfair 700
-- Live pill: gold border, gold text, blinking dot
+- `background: var(--bg2)`, `border: 1px solid var(--border-dim)`, `border-top: 2px solid var(--gold)` (3px in light)
+- Eyebrow "Motion Before the House" — Inter 10px gold
+- Motion title — Playfair 700 22px `--text`
+- Live pill: `background: var(--gold-dim)`, `border: 1px solid var(--border)`, gold text, blinking dot (`animation: blink 1.4s ease-in-out infinite`)
 
 ### Score Row
-- Split grid below header, `--bg3` background
-- Pro (left): gold badge, gold score number
-- Con (right, right-aligned): blue badge, blue score number
-- Persona role in Lora italic
+- CSS grid `1fr 1px 1fr`, `background: var(--bg3)`, same border as header (minus top border)
+- Pro side left-aligned, Con side right-aligned
+- Badge: Inter 9px 700 uppercase — Pro: `--gold`, Con: `--blue-lt` (light: `--blue`)
+- Persona name: Playfair 700 16px `--text`
+- Persona role: Lora italic 13px `--text-ui`
+- Score number: Playfair 900 34px — Pro: `--gold-lt` (light: `--gold`), Con: `--blue-lt` (light: `--blue`)
+- The "badge" is text-only (no background fill) — just the colored uppercase label above the name
 
-### Argument Cards (split-screen)
-- Two columns, Pro left / Con right — **layout unchanged from current**
-- Left border: 3px solid gold (pro) or blue (con)
-- Header: avatar initial (Playfair, 15px, circular), name (Playfair 700 14px), phase label (Inter 9px uppercase colored)
-- Pro header tint: `rgba(201,168,76,0.05)` — Con header tint: `rgba(42,109,181,0.05)`
-- **Body: Lora 400 16px, `--text-2` color, line-height 1.85** — primary reading surface, maximum contrast in both modes
-- Light mode body: pure `#ffffff` background
+### Argument Cards (split-screen — layout unchanged)
+- Two equal columns, Pro left / Con right
+- Column header: Inter 10px 700 uppercase, `padding-bottom: 10px`, `border-bottom: 2px solid` — Pro: `--gold`, Con: `--blue`
+- Card border: `border: 1px solid var(--border-dim)`, `border-left: 3px solid` — Pro: `--gold`, Con: `--blue`
+- Card header: avatar + name + phase label, `border-bottom: 1px solid var(--border-dim)`
+  - Pro header tint: `rgba(201,168,76,0.05)`, Con: `rgba(42,109,181,0.05)`
+- Avatar: 34px circle, Playfair 900 15px initial — Pro fill: `--gold-dim`, Pro ring: `1px solid var(--border)`, Con fill: `--blue-dim`, Con ring: `1px solid rgba(42,109,181,0.3)`
+- Phase label: Inter 9px 600 uppercase — Pro: `--gold`, Con: `--blue-lt` (light: `--blue`)
+- **Card body: `background: var(--bg2)` (dark) / `#ffffff` (light)**
+- **Body text: Lora 400 16px, `--text-2`, line-height 1.85, letter-spacing 0.01em**
+- **Bold spans within body text: Lora 700 16px, `--text` (one step brighter)**
 
-### Ornament Dividers
-- `✦` centered between two 1px horizontal rules
-- Used between hero and debate content
-- Dark: `opacity: 0.35`. Light: `opacity: 1` with very faint lines
+### Citation Badge (`CitationBadge.tsx`)
+- Replace current cyan with gold tones: border `1px solid var(--border)`, background `var(--gold-dim)`, text `--gold-lt` (dark) / `--gold` (light)
+- Hover popup: `background: var(--bg3)`, border `var(--border)`
+- "🌐 Verified Source" label: Inter 10px `--text-ui`
 
-### Dark/Light Toggle
-- Fixed top-right, Inter uppercase 11px
-- `☀ / ☾` label
-- Hover: gold text and border
+### Strategic Analysis Panel (`StrategicAnalysisPanel.tsx`)
+- Pro panel: border/accent `--gold`, header background `var(--gold-dim)`
+- Con panel: border/accent `--blue`, header background `var(--blue-dim)`
+- Replace current cyan/fuchsia with gold/blue respectively
+
+### Streaming Cursor (`StreamingText.tsx`)
+- Pro streaming cursor: `background: var(--gold)` (replaces `bg-cyan-400`)
+- Con streaming cursor: `background: var(--blue-lt)` (replaces `bg-fuchsia-400`)
+- Bold text within streamed content: `color: var(--text)` (replaces `text-white`)
+
+### History Card (`HistoryCard.tsx`)
+- Winner badge: `background: var(--gold-dim)`, text `--gold-lt` (Pro wins) / `background: var(--blue-dim)`, text `--blue-lt` (Con wins)
+- Score dots: Pro `--gold`, Con `--blue-lt`
+- Card border hover: `--border`
+- Topic title: Playfair Display 700
+
+### Phase Nav Completed Checkmarks
+- Replace `text-cyan-300` with `var(--gold)` for completed phase indicators
 
 ---
 
-## Pro/Con Color Assignment
+## Full Pro/Con Color Assignment
 
-| Element | Pro | Con |
-|---------|-----|-----|
-| Card border | Gold | Sapphire |
-| Score number | Gold light | Blue light |
-| Phase label | Gold | Blue light |
-| Avatar ring | Gold border | Blue border |
-| Column header underline | Gold | Sapphire |
+| Element | Pro (Gold) | Con (Sapphire) |
+|---------|-----------|----------------|
+| Argument card left-border | `--gold` | `--blue` |
+| Column header underline | `--gold` | `--blue` |
+| Score number | `--gold-lt` | `--blue-lt` |
+| Phase label (in card) | `--gold` | `--blue-lt` |
+| Avatar fill | `--gold-dim` | `--blue-dim` |
+| Avatar ring | `var(--border)` | `rgba(42,109,181,0.3)` |
+| Card header tint | `rgba(201,168,76,0.05)` | `rgba(42,109,181,0.05)` |
+| Column header text | `--gold` | `--blue-lt` |
+| Score badge label | `--gold` | `--blue-lt` |
+| Streaming cursor | `--gold` | `--blue-lt` |
+| Strategic panel accent | `--gold` + `--gold-dim` | `--blue` + `--blue-dim` |
+| History card winner badge | `--gold-dim` fill / `--gold-lt` text | `--blue-dim` fill / `--blue-lt` text |
+| History card score dot | `--gold` | `--blue-lt` |
 | Background glow | Gold (top-left) | Blue (bottom-right) |
 
 ---
@@ -173,9 +299,9 @@ SVG `feTurbulence` fractalNoise texture, `opacity: 0.045`, shifts position in 8-
 
 - Component file structure and names
 - Zustand store shape
-- SSE streaming logic
+- SSE streaming logic and event handling
 - Split-screen layout (Pro left, Con right)
-- Phase navigation order and behavior
+- Phase navigation order and gating behavior
 - Route structure
 - All backend code
 
@@ -184,15 +310,25 @@ SVG `feTurbulence` fractalNoise texture, `opacity: 0.045`, shifts position in 8-
 ## Implementation Scope
 
 Files to update:
-- `frontend/src/app/globals.css` — CSS custom properties, keyframe animations, base styles
-- `frontend/src/app/layout.tsx` — font imports (add Playfair Display + Lora, remove Geist)
-- `frontend/src/app/page.tsx` — landing page hero and layout
-- `frontend/src/app/debates/[id]/page.tsx` — debate view page
-- `frontend/src/app/browse/page.tsx` — browse page
-- `frontend/src/app/dashboard/page.tsx` — dashboard
-- `frontend/src/app/auth/page.tsx` — auth page
-- `frontend/src/components/debate/ArgumentCard.tsx` — argument card styling
-- `frontend/src/components/debate/PhaseNav.tsx` — phase nav styling
-- `frontend/src/components/debate/StreamingText.tsx` — reading text styles
-- `frontend/src/components/debate/StrategicAnalysisPanel.tsx` — internal analysis panel
-- `frontend/src/components/dashboard/HistoryCard.tsx` — history card styling
+
+**Core styles:**
+- `frontend/src/app/globals.css` — CSS custom property tokens, keyframe animations, base body styles, ornament/eyebrow CSS classes. Remove Geist font variables.
+
+**Layout:**
+- `frontend/src/app/layout.tsx` — Replace Geist font imports with Playfair Display + Lora + Inter. Add masthead-rule `<div>` and theme-init `<script>` (reads localStorage, sets `data-theme` before first paint to avoid flash).
+
+**Pages:**
+- `frontend/src/app/page.tsx` — Landing hero (centered, new type), ornament divider
+- `frontend/src/app/debates/[id]/page.tsx` — Debate view: phase nav, header card, score row, split-screen columns, background layers
+- `frontend/src/app/debates/new/page.tsx` — New debate wizard: apply token-based colors, Inter/Playfair type
+- `frontend/src/app/browse/page.tsx` — Browse page styling
+- `frontend/src/app/dashboard/page.tsx` — Dashboard styling
+- `frontend/src/app/auth/page.tsx` — Auth page styling
+
+**Components:**
+- `frontend/src/components/debate/ArgumentCard.tsx` — Card layout, avatar, header, body text (Lora)
+- `frontend/src/components/debate/PhaseNav.tsx` — Phase nav styling, completed indicator color
+- `frontend/src/components/debate/StreamingText.tsx` — Cursor color, bold text color
+- `frontend/src/components/debate/CitationBadge.tsx` — Gold/neutral palette replacing cyan
+- `frontend/src/components/debate/StrategicAnalysisPanel.tsx` — Gold/blue replacing cyan/fuchsia
+- `frontend/src/components/dashboard/HistoryCard.tsx` — Winner badge, score dots

--- a/Docs/superpowers/specs/2026-03-24-ui-redesign-design.md
+++ b/Docs/superpowers/specs/2026-03-24-ui-redesign-design.md
@@ -1,0 +1,198 @@
+# UI Redesign: Ink, Gold & Sapphire Design System
+
+**Date:** 2026-03-24
+**Status:** Approved
+**Scope:** Full frontend visual redesign — styling only, no layout or functionality changes
+
+---
+
+## Goal
+
+Replace the generic "vibe-coded" aesthetic (cyan/fuchsia gradients, glassmorphism blobs, Geist font) with a distinctive editorial-meets-theatrical identity that feels serious, captivating, and unlike every other AI app. The redesign is **style-only** — existing component structure, routing, Zustand store, and split-screen layout are preserved exactly.
+
+---
+
+## Design Identity
+
+**Concept:** A premium debate journal. The gravity of a broadsheet newspaper meets the drama of an Oxford Union debate hall. Restrained, typographic, authoritative — with subtle ambient life in the background.
+
+**What it is not:** Neon glows, animated gradient blobs, glassmorphism, generic dark mode with cyan/purple accents.
+
+---
+
+## Color System
+
+### Dark Mode (default)
+
+| Token | Value | Usage |
+|-------|-------|-------|
+| `--bg` | `#0c0c10` | Page background |
+| `--bg2` | `#13131a` | Card/panel backgrounds |
+| `--bg3` | `#1c1c26` | Elevated surfaces, phase nav active |
+| `--gold` | `#c9a84c` | Pro side, primary actions, accents |
+| `--gold-lt` | `#e8c97a` | Pro scores, hero italic, hover states |
+| `--gold-dim` | `rgba(201,168,76,0.13)` | Avatar backgrounds, subtle fills |
+| `--blue` | `#2a6db5` | Con side border, structural accents |
+| `--blue-lt` | `#5a9fe0` | Con labels, scores, hover states |
+| `--blue-dim` | `rgba(42,109,181,0.13)` | Avatar backgrounds |
+| `--text` | `#f2ead6` | Primary text (headings, names) |
+| `--text-2` | `#d4c9ae` | Argument body text — high contrast reading |
+| `--text-ui` | `#8a7a60` | Labels, meta, dim UI chrome |
+| `--border` | `rgba(201,168,76,0.2)` | Visible borders |
+| `--border-dim` | `rgba(255,255,255,0.07)` | Subtle structural dividers |
+
+### Light Mode (user-toggled)
+
+| Token | Value | Usage |
+|-------|-------|-------|
+| `--bg` | `#ffffff` | Clean white page |
+| `--bg2` | `#f7f7f5` | Card surface |
+| `--bg3` | `#eeeeea` | Elevated surfaces |
+| `--gold` | `#8a5e0a` | Pro accents (deep amber for legibility) |
+| `--gold-lt` | `#a87214` | Pro scores |
+| `--blue` | `#0f4080` | Con accents (deep navy) |
+| `--blue-lt` | `#1a5aa8` | Con scores |
+| `--text` | `#0a0a0a` | Near-black primary text |
+| `--text-2` | `#1a1a1a` | Argument body — near-black |
+| `--text-ui` | `#767676` | Labels and meta |
+| `--border` | `rgba(0,0,0,0.15)` | Visible borders |
+| `--border-dim` | `rgba(0,0,0,0.08)` | Subtle dividers |
+
+**Light mode specifics:**
+- All background animations disabled (breathe glows, grain, vignette → opacity 0)
+- A 3px solid black masthead rule appears at the very top of the page
+- Argument card bodies use pure `#ffffff` for maximum reading contrast
+- No warm parchment tones — clean newspaper white throughout
+
+---
+
+## Typography
+
+Three-tier system. Each tier has a single job.
+
+| Font | Role | Usage |
+|------|------|-------|
+| **Playfair Display** | Drama & identity | Page headlines, debate titles, persona names, scores |
+| **Lora** | Reading comfort | Argument body text, hero subtitle, persona roles |
+| **Inter** | UI chrome | Phase nav, labels, badges, eyebrows, buttons |
+
+**Sizes (base 16px):**
+- Hero h1: `clamp(52px, 9vw, 96px)`, weight 900, tracking -2px
+- Hero italic sub-line: `clamp(26px, 4vw, 44px)`, Playfair italic 700, color `--gold-lt`
+- Hero body: 18px Lora 400
+- Debate title: 22px Playfair 700
+- Persona name: 16px Playfair 700
+- Score number: 34px Playfair 900
+- Argument body text: **16px Lora 400, line-height 1.85** — this is the primary reading surface
+- Section labels / eyebrows: 10px Inter 700, letter-spacing 4px, uppercase
+- Phase nav: 9px Inter 600, letter-spacing 2px, uppercase
+
+---
+
+## Background System (dark mode only)
+
+Three independent breathing radial glows + animated film grain + vignette. All disabled in light mode.
+
+### Glow layers
+1. **Gold glow** — `80vw` circle, top-left, `rgba(201,168,76,0.18)` core fading to transparent. Animates: scale 1→1.2→0.9, drifts slightly, period 11s.
+2. **Blue glow** — `65vw` circle, bottom-right, `rgba(42,109,181,0.2)` core. Animates: scale 1→1.25→0.85, opposite drift, period 15s.
+3. **Mid glow** — `45vw` circle, center-page, faint gold. Animates: scale 1→1.35, period 19s.
+
+Each layer uses independent timing so they never sync — creates a continuously shifting, non-repetitive breathing effect.
+
+### Film grain
+SVG `feTurbulence` fractalNoise texture, `opacity: 0.045`, shifts position in 8-step increments every 8s. Adds texture without pattern repetition.
+
+### Vignette
+`radial-gradient` from transparent center to `rgba(0,0,0,0.65)` edges. Focuses the eye to center content, adds depth.
+
+---
+
+## Component Styling
+
+### Hero Section
+- Centered layout (text-align: center)
+- Eyebrow: Inter uppercase with decorative line flanks (`::before` / `::after`)
+- H1 "Two minds." — massive Playfair 900
+- Italic gold sub-line "One argument." — Playfair italic, gold, visually subordinate but present
+- Body: Lora 400, muted color (`--text-ui`)
+
+### Phase Navigation
+- Horizontal tab bar, full width
+- Active phase: gold underline (2px), `--bg3` background, gold text
+- Completed phases: dim underline, muted text
+- Pending phases: no underline, dim text
+- Inter 9px uppercase throughout
+
+### Debate Header Card
+- `--bg2` background, `border-top: 2px solid var(--gold)` (3px in light mode)
+- "Motion Before the House" eyebrow in gold
+- Debate title in Playfair 700
+- Live pill: gold border, gold text, blinking dot
+
+### Score Row
+- Split grid below header, `--bg3` background
+- Pro (left): gold badge, gold score number
+- Con (right, right-aligned): blue badge, blue score number
+- Persona role in Lora italic
+
+### Argument Cards (split-screen)
+- Two columns, Pro left / Con right — **layout unchanged from current**
+- Left border: 3px solid gold (pro) or blue (con)
+- Header: avatar initial (Playfair, 15px, circular), name (Playfair 700 14px), phase label (Inter 9px uppercase colored)
+- Pro header tint: `rgba(201,168,76,0.05)` — Con header tint: `rgba(42,109,181,0.05)`
+- **Body: Lora 400 16px, `--text-2` color, line-height 1.85** — primary reading surface, maximum contrast in both modes
+- Light mode body: pure `#ffffff` background
+
+### Ornament Dividers
+- `✦` centered between two 1px horizontal rules
+- Used between hero and debate content
+- Dark: `opacity: 0.35`. Light: `opacity: 1` with very faint lines
+
+### Dark/Light Toggle
+- Fixed top-right, Inter uppercase 11px
+- `☀ / ☾` label
+- Hover: gold text and border
+
+---
+
+## Pro/Con Color Assignment
+
+| Element | Pro | Con |
+|---------|-----|-----|
+| Card border | Gold | Sapphire |
+| Score number | Gold light | Blue light |
+| Phase label | Gold | Blue light |
+| Avatar ring | Gold border | Blue border |
+| Column header underline | Gold | Sapphire |
+| Background glow | Gold (top-left) | Blue (bottom-right) |
+
+---
+
+## What Does Not Change
+
+- Component file structure and names
+- Zustand store shape
+- SSE streaming logic
+- Split-screen layout (Pro left, Con right)
+- Phase navigation order and behavior
+- Route structure
+- All backend code
+
+---
+
+## Implementation Scope
+
+Files to update:
+- `frontend/src/app/globals.css` — CSS custom properties, keyframe animations, base styles
+- `frontend/src/app/layout.tsx` — font imports (add Playfair Display + Lora, remove Geist)
+- `frontend/src/app/page.tsx` — landing page hero and layout
+- `frontend/src/app/debates/[id]/page.tsx` — debate view page
+- `frontend/src/app/browse/page.tsx` — browse page
+- `frontend/src/app/dashboard/page.tsx` — dashboard
+- `frontend/src/app/auth/page.tsx` — auth page
+- `frontend/src/components/debate/ArgumentCard.tsx` — argument card styling
+- `frontend/src/components/debate/PhaseNav.tsx` — phase nav styling
+- `frontend/src/components/debate/StreamingText.tsx` — reading text styles
+- `frontend/src/components/debate/StrategicAnalysisPanel.tsx` — internal analysis panel
+- `frontend/src/components/dashboard/HistoryCard.tsx` — history card styling

--- a/frontend/src/app/auth/page.tsx
+++ b/frontend/src/app/auth/page.tsx
@@ -80,11 +80,8 @@ function AuthPageInner() {
 
   return (
     <div className="min-h-screen bg-surface text-on-surface flex flex-col relative font-sans overflow-hidden">
-      {/* Animated Background */}
+      {/* Background */}
       <div className="absolute inset-0 pointer-events-none overflow-hidden z-0">
-        <div className="absolute -top-[20%] -left-[10%] w-[50vw] h-[50vw] bg-fuchsia-600/15 blur-[120px] rounded-none mix-blend-screen animate-[pulse_8s_ease-in-out_infinite]" />
-        <div className="absolute top-[40%] -right-[15%] w-[60vw] h-[60vw] bg-blue-600/15 blur-[120px] rounded-none mix-blend-screen animate-[pulse_10s_ease-in-out_infinite_1s]" />
-        <div className="absolute -bottom-[10%] left-[30%] w-[40vw] h-[40vw] bg-violet-600/15 blur-[120px] rounded-none mix-blend-screen animate-[pulse_9s_ease-in-out_infinite_2s]" />
       </div>
 
       {/* Header */}
@@ -210,7 +207,7 @@ function AuthPageInner() {
               >
                 {loading ? (
                   <span className="flex items-center justify-center gap-2">
-                    <span className="w-4 h-4 rounded-none border-2 border-white/40 border-t-white animate-spin" />
+                    <span className="w-4 h-4 rounded-none border-2 border-outline border-t-on-surface animate-spin" />
                     {mode === "login" ? "Signing in..." : "Creating account..."}
                   </span>
                 ) : (

--- a/frontend/src/app/auth/page.tsx
+++ b/frontend/src/app/auth/page.tsx
@@ -79,21 +79,21 @@ function AuthPageInner() {
   };
 
   return (
-    <div className="min-h-screen bg-slate-950 text-gray-100 flex flex-col relative font-sans overflow-hidden">
+    <div className="min-h-screen bg-surface text-on-surface flex flex-col relative font-sans overflow-hidden">
       {/* Animated Background */}
       <div className="absolute inset-0 pointer-events-none overflow-hidden z-0">
-        <div className="absolute -top-[20%] -left-[10%] w-[50vw] h-[50vw] bg-fuchsia-600/15 blur-[120px] rounded-full mix-blend-screen animate-[pulse_8s_ease-in-out_infinite]" />
-        <div className="absolute top-[40%] -right-[15%] w-[60vw] h-[60vw] bg-blue-600/15 blur-[120px] rounded-full mix-blend-screen animate-[pulse_10s_ease-in-out_infinite_1s]" />
-        <div className="absolute -bottom-[10%] left-[30%] w-[40vw] h-[40vw] bg-violet-600/15 blur-[120px] rounded-full mix-blend-screen animate-[pulse_9s_ease-in-out_infinite_2s]" />
+        <div className="absolute -top-[20%] -left-[10%] w-[50vw] h-[50vw] bg-fuchsia-600/15 blur-[120px] rounded-none mix-blend-screen animate-[pulse_8s_ease-in-out_infinite]" />
+        <div className="absolute top-[40%] -right-[15%] w-[60vw] h-[60vw] bg-blue-600/15 blur-[120px] rounded-none mix-blend-screen animate-[pulse_10s_ease-in-out_infinite_1s]" />
+        <div className="absolute -bottom-[10%] left-[30%] w-[40vw] h-[40vw] bg-violet-600/15 blur-[120px] rounded-none mix-blend-screen animate-[pulse_9s_ease-in-out_infinite_2s]" />
       </div>
 
       {/* Header */}
-      <header className="relative z-10 border-b border-white/10 bg-black/40 backdrop-blur-3xl px-8 py-5 flex items-center justify-between shadow-sm">
+      <header className="relative z-10 border-b border-outline-variant bg-black/40 backdrop-blur-3xl px-8 py-5 flex items-center justify-between shadow-sm">
         <Link href="/" className="flex items-center gap-3 group">
-          <div className="w-8 h-8 rounded-xl bg-gradient-to-br from-cyan-400 via-blue-500 to-purple-600 flex items-center justify-center shadow-[0_0_20px_rgba(56,189,248,0.5)] group-hover:shadow-[0_0_30px_rgba(56,189,248,0.7)] transition-shadow">
-            <span className="text-white font-bold text-sm">🎯</span>
+          <div className="w-8 h-8 rounded-none bg-pro flex items-center justify-center">
+            <span className="text-[#00195b] font-bold text-sm">🎯</span>
           </div>
-          <span className="text-xl font-black tracking-tighter bg-clip-text text-transparent bg-gradient-to-r from-white to-gray-400">
+          <span className="text-xl font-black tracking-tighter text-on-surface">
             DebateMeBro
           </span>
         </Link>
@@ -103,15 +103,15 @@ function AuthPageInner() {
       <main className="relative z-10 flex-1 flex items-center justify-center px-6 py-16">
         <div className="w-full max-w-md">
           {/* Card */}
-          <div className="rounded-3xl border border-white/10 bg-white/[0.03] backdrop-blur-2xl shadow-[0_8px_60px_rgba(0,0,0,0.5)] overflow-hidden">
+          <div className="rounded-none border border-outline-variant bg-surface-container overflow-hidden">
             {/* Tab Switcher */}
-            <div className="flex border-b border-white/10">
+            <div className="flex border-b border-outline-variant">
               <button
                 onClick={() => { setMode("login"); setError(null); }}
                 className={`flex-1 py-4 text-sm font-black uppercase tracking-widest transition-all ${
                   mode === "login"
-                    ? "text-white bg-white/[0.05] border-b-2 border-cyan-400"
-                    : "text-gray-500 hover:text-gray-300"
+                    ? "text-on-surface bg-surface-container border-b-2 border-pro"
+                    : "border-b-2 border-transparent text-on-surface-variant hover:bg-surface-high"
                 }`}
               >
                 Sign In
@@ -120,8 +120,8 @@ function AuthPageInner() {
                 onClick={() => { setMode("register"); setError(null); }}
                 className={`flex-1 py-4 text-sm font-black uppercase tracking-widest transition-all ${
                   mode === "register"
-                    ? "text-white bg-white/[0.05] border-b-2 border-fuchsia-400"
-                    : "text-gray-500 hover:text-gray-300"
+                    ? "text-on-surface bg-surface-container border-b-2 border-pro"
+                    : "border-b-2 border-transparent text-on-surface-variant hover:bg-surface-high"
                 }`}
               >
                 Sign Up
@@ -131,10 +131,10 @@ function AuthPageInner() {
             {/* Form */}
             <form onSubmit={handleSubmit} className="p-8 space-y-5">
               <div className="text-center mb-6">
-                <h1 className="text-2xl font-black text-white mb-2">
+                <h1 className="text-2xl font-black text-on-surface mb-2">
                   {mode === "login" ? "Welcome back" : "Create your account"}
                 </h1>
-                <p className="text-sm text-gray-500">
+                <p className="text-sm text-on-surface-variant">
                   {mode === "login"
                     ? "Sign in to vote, view history, and track debates."
                     : "Join to participate in AI-powered debates."}
@@ -143,14 +143,14 @@ function AuthPageInner() {
 
               {/* Error */}
               {error && (
-                <div className="px-4 py-3 rounded-xl bg-red-500/10 border border-red-500/30 text-red-400 text-sm font-medium flex items-center gap-2">
+                <div className="px-4 py-3 rounded-none bg-con/10 border border-con/30 text-con text-sm font-medium flex items-center gap-2">
                   <span>⚠️</span> {error}
                 </div>
               )}
 
               {/* Email */}
               <div>
-                <label htmlFor="email" className="block text-xs font-bold uppercase tracking-widest text-gray-400 mb-2">
+                <label htmlFor="email" className="block text-xs font-bold uppercase tracking-widest text-on-surface-variant mb-2">
                   Email
                 </label>
                 <input
@@ -160,13 +160,13 @@ function AuthPageInner() {
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
                   placeholder="you@example.com"
-                  className="w-full px-4 py-3 rounded-xl bg-white/5 border border-white/10 text-white placeholder-gray-600 text-sm focus:outline-none focus:ring-2 focus:ring-cyan-500/50 focus:border-cyan-500/50 transition-all"
+                  className="w-full px-4 py-3 rounded-none border-0 border-b border-outline bg-surface-high text-on-surface placeholder-on-surface-variant text-sm focus:outline-none focus:border-pro transition-all"
                 />
               </div>
 
               {/* Password */}
               <div>
-                <label htmlFor="password" className="block text-xs font-bold uppercase tracking-widest text-gray-400 mb-2">
+                <label htmlFor="password" className="block text-xs font-bold uppercase tracking-widest text-on-surface-variant mb-2">
                   Password
                 </label>
                 <input
@@ -176,14 +176,14 @@ function AuthPageInner() {
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}
                   placeholder="••••••••"
-                  className="w-full px-4 py-3 rounded-xl bg-white/5 border border-white/10 text-white placeholder-gray-600 text-sm focus:outline-none focus:ring-2 focus:ring-cyan-500/50 focus:border-cyan-500/50 transition-all"
+                  className="w-full px-4 py-3 rounded-none border-0 border-b border-outline bg-surface-high text-on-surface placeholder-on-surface-variant text-sm focus:outline-none focus:border-pro transition-all"
                 />
               </div>
 
               {/* Confirm Password (register only) */}
               {mode === "register" && (
                 <div>
-                  <label htmlFor="confirmPassword" className="block text-xs font-bold uppercase tracking-widest text-gray-400 mb-2">
+                  <label htmlFor="confirmPassword" className="block text-xs font-bold uppercase tracking-widest text-on-surface-variant mb-2">
                     Confirm Password
                   </label>
                   <input
@@ -193,7 +193,7 @@ function AuthPageInner() {
                     value={confirmPassword}
                     onChange={(e) => setConfirmPassword(e.target.value)}
                     placeholder="••••••••"
-                    className="w-full px-4 py-3 rounded-xl bg-white/5 border border-white/10 text-white placeholder-gray-600 text-sm focus:outline-none focus:ring-2 focus:ring-fuchsia-500/50 focus:border-fuchsia-500/50 transition-all"
+                    className="w-full px-4 py-3 rounded-none border-0 border-b border-outline bg-surface-high text-on-surface placeholder-on-surface-variant text-sm focus:outline-none focus:border-pro transition-all"
                   />
                 </div>
               )}
@@ -202,15 +202,15 @@ function AuthPageInner() {
               <button
                 type="submit"
                 disabled={loading}
-                className={`w-full py-3.5 rounded-xl text-sm font-black uppercase tracking-widest transition-all border ${
+                className={`w-full py-3.5 rounded-none uppercase tracking-widest text-sm font-black transition-all border ${
                   mode === "login"
-                    ? "bg-gradient-to-r from-cyan-600 to-blue-600 hover:from-cyan-500 hover:to-blue-500 border-cyan-500/30 shadow-[0_0_30px_rgba(56,189,248,0.2)] hover:shadow-[0_0_40px_rgba(56,189,248,0.4)]"
-                    : "bg-gradient-to-r from-fuchsia-600 to-purple-600 hover:from-fuchsia-500 hover:to-purple-500 border-fuchsia-500/30 shadow-[0_0_30px_rgba(217,70,239,0.2)] hover:shadow-[0_0_40px_rgba(217,70,239,0.4)]"
-                } text-white disabled:opacity-50 disabled:cursor-not-allowed hover:scale-[1.02]`}
+                    ? "bg-pro text-[#00195b] border-pro/30"
+                    : "bg-con text-[#4a0004] border-con/30"
+                } disabled:opacity-50 disabled:cursor-not-allowed`}
               >
                 {loading ? (
                   <span className="flex items-center justify-center gap-2">
-                    <span className="w-4 h-4 rounded-full border-2 border-white/40 border-t-white animate-spin" />
+                    <span className="w-4 h-4 rounded-none border-2 border-white/40 border-t-white animate-spin" />
                     {mode === "login" ? "Signing in..." : "Creating account..."}
                   </span>
                 ) : (
@@ -219,18 +219,18 @@ function AuthPageInner() {
               </button>
 
               {/* Switch mode link */}
-              <p className="text-center text-sm text-gray-500 pt-2">
+              <p className="text-center text-sm text-on-surface-variant pt-2">
                 {mode === "login" ? (
                   <>
                     Don&apos;t have an account?{" "}
-                    <button type="button" onClick={() => { setMode("register"); setError(null); }} className="text-fuchsia-400 hover:text-fuchsia-300 font-bold transition-colors">
+                    <button type="button" onClick={() => { setMode("register"); setError(null); }} className="text-con hover:text-con font-bold transition-colors">
                       Sign up
                     </button>
                   </>
                 ) : (
                   <>
                     Already have an account?{" "}
-                    <button type="button" onClick={() => { setMode("login"); setError(null); }} className="text-cyan-400 hover:text-cyan-300 font-bold transition-colors">
+                    <button type="button" onClick={() => { setMode("login"); setError(null); }} className="text-pro hover:text-pro font-bold transition-colors">
                       Sign in
                     </button>
                   </>
@@ -240,7 +240,7 @@ function AuthPageInner() {
           </div>
 
           {/* Bottom text */}
-          <p className="text-center text-xs text-gray-600 mt-6">
+          <p className="text-center text-xs text-on-surface-variant mt-6">
             By signing up, you agree to participate in AI-powered debates for educational purposes.
           </p>
         </div>
@@ -252,8 +252,8 @@ function AuthPageInner() {
 export default function AuthPage() {
   return (
     <Suspense fallback={
-      <div className="min-h-screen bg-slate-950 flex items-center justify-center">
-        <div className="w-8 h-8 rounded-full border-2 border-cyan-400 border-t-transparent animate-spin" />
+      <div className="min-h-screen bg-surface flex items-center justify-center">
+        <div className="w-8 h-8 rounded-none border-2 border-pro border-t-transparent animate-spin" />
       </div>
     }>
       <AuthPageInner />

--- a/frontend/src/app/browse/page.tsx
+++ b/frontend/src/app/browse/page.tsx
@@ -59,26 +59,26 @@ export default function BrowsePage() {
   });
 
   return (
-    <div className="min-h-screen bg-slate-950 text-gray-100 flex flex-col relative font-sans overflow-hidden">
+    <div className="min-h-screen bg-surface text-on-surface flex flex-col relative font-sans overflow-hidden">
       {/* Background */}
       <div className="absolute inset-0 pointer-events-none overflow-hidden z-0">
-        <div className="absolute -top-[20%] -left-[10%] w-[50vw] h-[50vw] bg-purple-600/10 blur-[120px] rounded-full mix-blend-screen animate-[pulse_8s_ease-in-out_infinite]" />
-        <div className="absolute top-[40%] -right-[15%] w-[60vw] h-[60vw] bg-blue-600/10 blur-[120px] rounded-full mix-blend-screen animate-[pulse_10s_ease-in-out_infinite_1s]" />
+        <div className="absolute -top-[20%] -left-[10%] w-[50vw] h-[50vw] bg-purple-600/10 blur-[120px] rounded-none mix-blend-screen animate-[pulse_8s_ease-in-out_infinite]" />
+        <div className="absolute top-[40%] -right-[15%] w-[60vw] h-[60vw] bg-blue-600/10 blur-[120px] rounded-none mix-blend-screen animate-[pulse_10s_ease-in-out_infinite_1s]" />
       </div>
 
       {/* Header */}
-      <header className="relative z-10 border-b border-white/10 bg-black/40 backdrop-blur-3xl px-8 py-5 flex items-center justify-between shadow-sm">
+      <header className="relative z-10 border-b border-outline-variant bg-black/40 backdrop-blur-3xl px-8 py-5 flex items-center justify-between shadow-sm">
         <Link href="/" className="flex items-center gap-3 group">
-          <div className="w-8 h-8 rounded-xl bg-gradient-to-br from-cyan-400 via-blue-500 to-purple-600 flex items-center justify-center shadow-[0_0_20px_rgba(56,189,248,0.5)] group-hover:shadow-[0_0_30px_rgba(56,189,248,0.7)] transition-shadow">
-            <span className="text-white font-bold text-sm">🎯</span>
+          <div className="w-8 h-8 rounded-none bg-pro flex items-center justify-center">
+            <span className="text-[#00195b] font-bold text-sm">🎯</span>
           </div>
-          <span className="text-xl font-black tracking-tighter bg-clip-text text-transparent bg-gradient-to-r from-white to-gray-400">
+          <span className="text-xl font-black tracking-tighter text-on-surface">
             DebateMeBro
           </span>
         </Link>
         <div className="flex items-center gap-4">
           {isLoggedIn && (
-            <Link href="/dashboard" className="text-sm text-gray-400 hover:text-white transition-colors font-medium">
+            <Link href="/dashboard" className="text-sm text-on-surface-variant hover:text-on-surface transition-colors font-medium">
               Dashboard
             </Link>
           )}
@@ -89,27 +89,27 @@ export default function BrowsePage() {
       <main className="relative z-10 flex-1 px-6 py-12 max-w-5xl mx-auto w-full">
         <div className="flex flex-col md:flex-row md:items-end justify-between gap-6 mb-10">
           <div>
-            <h1 className="text-3xl md:text-4xl font-black text-white mb-2 tracking-tight">Browse Debates</h1>
-            <p className="text-gray-500 text-sm">All public AI debates — watch, learn, and like the best ones.</p>
+            <h1 className="text-3xl md:text-4xl font-black text-on-surface mb-2 tracking-tight">Browse Debates</h1>
+            <p className="text-on-surface-variant text-sm">All public AI debates — watch, learn, and like the best ones.</p>
           </div>
           <div className="flex items-center gap-3">
-            <div className="flex gap-1.5 bg-white/[0.03] rounded-xl p-1 border border-white/10">
+            <div className="flex gap-1.5 bg-surface-container rounded-none p-1 border border-outline-variant">
               <button
                 onClick={() => setSortBy("recent")}
-                className={`px-4 py-2 rounded-lg text-xs font-bold uppercase tracking-widest transition-all ${
+                className={`rounded-none border border-outline-variant uppercase tracking-widest text-xs px-4 py-2 font-bold transition-all ${
                   sortBy === "recent"
-                    ? "bg-white/10 text-white shadow-sm"
-                    : "text-gray-500 hover:text-gray-300"
+                    ? "bg-surface-bright border-outline text-on-surface"
+                    : "text-on-surface-variant hover:text-on-surface"
                 }`}
               >
                 Recent
               </button>
               <button
                 onClick={() => setSortBy("liked")}
-                className={`px-4 py-2 rounded-lg text-xs font-bold uppercase tracking-widest transition-all ${
+                className={`rounded-none border border-outline-variant uppercase tracking-widest text-xs px-4 py-2 font-bold transition-all ${
                   sortBy === "liked"
-                    ? "bg-white/10 text-white shadow-sm"
-                    : "text-gray-500 hover:text-gray-300"
+                    ? "bg-surface-bright border-outline text-on-surface"
+                    : "text-on-surface-variant hover:text-on-surface"
                 }`}
               >
                 Most Liked
@@ -117,7 +117,7 @@ export default function BrowsePage() {
             </div>
             <Link
               href="/"
-              className="px-5 py-2.5 rounded-xl text-xs font-black uppercase tracking-widest bg-gradient-to-r from-cyan-600 to-blue-600 hover:from-cyan-500 hover:to-blue-500 text-white border border-cyan-500/30 shadow-[0_0_20px_rgba(6,182,212,0.15)] hover:shadow-[0_0_30px_rgba(6,182,212,0.3)] transition-all"
+              className="bg-pro text-[#00195b] rounded-none uppercase tracking-widest px-6 py-3 text-xs font-black transition-all"
             >
               + New Debate
             </Link>
@@ -127,21 +127,21 @@ export default function BrowsePage() {
         {loading ? (
           <div className="space-y-4">
             {[1, 2, 3, 4].map((i) => (
-              <div key={i} className="animate-pulse bg-white/[0.03] border border-white/10 rounded-2xl p-6 h-36" />
+              <div key={i} className="animate-pulse bg-surface-container border border-outline-variant rounded-none p-6 h-36" />
             ))}
           </div>
         ) : error ? (
-          <div className="text-center py-20 bg-red-500/10 border border-red-500/20 rounded-2xl">
-            <p className="text-red-400 mb-4">{error}</p>
-            <button onClick={loadDebates} className="px-6 py-2 bg-red-500/20 text-red-300 rounded-xl hover:bg-red-500/30 transition-colors">
+          <div className="text-center py-20 bg-con/10 border border-con/30 rounded-none">
+            <p className="text-con mb-4">{error}</p>
+            <button onClick={loadDebates} className="px-6 py-2 bg-con/20 text-con rounded-none hover:bg-con/30 transition-colors">
               Retry
             </button>
           </div>
         ) : sorted.length === 0 ? (
           <div className="text-center py-20">
             <div className="text-5xl mb-4 opacity-30">🌐</div>
-            <p className="text-gray-500 text-lg mb-6">No debates yet. Be the first!</p>
-            <Link href="/" className="inline-block px-8 py-3 bg-gradient-to-r from-cyan-500 to-blue-600 text-white rounded-xl font-bold transition-all hover:shadow-[0_0_30px_rgba(6,182,212,0.4)]">
+            <p className="text-on-surface-variant text-lg mb-6">No debates yet. Be the first!</p>
+            <Link href="/" className="inline-block bg-pro text-[#00195b] rounded-none uppercase tracking-widest px-6 py-3 font-bold transition-all">
               Start a Debate →
             </Link>
           </div>
@@ -151,8 +151,8 @@ export default function BrowsePage() {
             {sorted.map((debate) => {
               const winner = debate.winner === "pro" ? "Pro" : debate.winner === "con" ? "Con" : null;
               const winnerColor = debate.winner === "pro"
-                ? "bg-cyan-500/20 text-cyan-400 border-cyan-500/30"
-                : "bg-fuchsia-500/20 text-fuchsia-400 border-fuchsia-500/30";
+                ? "bg-pro/10 border-pro/30 text-pro"
+                : "bg-con/10 border-con/30 text-con";
               const date = new Date(debate.created_at).toLocaleDateString(undefined, {
                 year: "numeric", month: "short", day: "numeric",
               });
@@ -160,38 +160,38 @@ export default function BrowsePage() {
               return (
                 <div
                   key={debate.id}
-                  className="group rounded-2xl bg-white/[0.03] border border-white/10 hover:bg-white/[0.06] hover:border-white/20 hover:shadow-[0_4px_40px_rgba(0,0,0,0.3)] hover:scale-[1.005] transition-all duration-200"
+                  className="group rounded-none bg-surface-container border border-outline-variant hover:bg-surface-high transition-colors duration-200"
                 >
                   <div className="flex items-start gap-5 p-6">
                     <Link href={`/debates/${debate.id}`} className="flex-1 min-w-0">
                       <div className="flex items-center gap-3 mb-2">
-                        <h3 className="text-lg font-black text-white group-hover:text-cyan-300 transition-colors truncate tracking-tight">
+                        <h3 className="text-lg font-black text-on-surface group-hover:text-pro transition-colors truncate tracking-tight">
                           {debate.topic}
                         </h3>
                         {winner && (
-                          <span className={`shrink-0 px-2.5 py-0.5 rounded-full text-[10px] font-black uppercase border ${winnerColor}`}>
+                          <span className={`shrink-0 px-2.5 py-0.5 rounded-none text-[10px] font-black uppercase border ${winnerColor}`}>
                             {winner} wins
                           </span>
                         )}
                       </div>
                       {debate.resolution && (
-                        <p className="text-sm text-gray-400 mb-3 line-clamp-2 leading-relaxed">{debate.resolution}</p>
+                        <p className="text-sm text-on-surface-variant mb-3 line-clamp-2 leading-relaxed">{debate.resolution}</p>
                       )}
-                      <div className="flex items-center flex-wrap gap-4 text-xs text-gray-500">
+                      <div className="flex items-center flex-wrap gap-4 text-xs text-on-surface-variant">
                         <span className="font-medium">{date}</span>
-                        <span className="w-px h-3 bg-white/10" />
+                        <span className="w-px h-3 bg-outline-variant" />
                         <span className="flex items-center gap-1.5 font-mono">
-                          <span className="w-2 h-2 rounded-full bg-cyan-400 shadow-[0_0_6px_rgba(6,182,212,0.5)]" />
-                          <span className="text-cyan-400/80">{debate.pro_score?.toFixed(1) || "0.0"}</span>
+                          <span className="w-2 h-2 rounded-none bg-pro" />
+                          <span className="text-pro">{debate.pro_score?.toFixed(1) || "0.0"}</span>
                         </span>
-                        <span className="text-gray-600">vs</span>
+                        <span className="text-on-surface-variant">vs</span>
                         <span className="flex items-center gap-1.5 font-mono">
-                          <span className="w-2 h-2 rounded-full bg-fuchsia-400 shadow-[0_0_6px_rgba(217,70,239,0.5)]" />
-                          <span className="text-fuchsia-400/80">{debate.con_score?.toFixed(1) || "0.0"}</span>
+                          <span className="w-2 h-2 rounded-none bg-con" />
+                          <span className="text-con">{debate.con_score?.toFixed(1) || "0.0"}</span>
                         </span>
                         {debate.turn_count > 0 && (
                           <>
-                            <span className="w-px h-3 bg-white/10" />
+                            <span className="w-px h-3 bg-outline-variant" />
                             <span>{debate.turn_count} turns</span>
                           </>
                         )}
@@ -199,10 +199,10 @@ export default function BrowsePage() {
                     </Link>
                     <button
                       onClick={(e) => { e.preventDefault(); handleLike(debate.id); }}
-                      className={`shrink-0 flex flex-col items-center gap-1 px-3 py-2.5 rounded-xl transition-all duration-200 ${
+                      className={`shrink-0 flex flex-col items-center gap-1 px-3 py-2.5 rounded-none transition-all duration-200 ${
                         debate.user_liked
-                          ? "bg-pink-500/20 text-pink-400 border border-pink-500/30 shadow-[0_0_15px_rgba(236,72,153,0.15)]"
-                          : "bg-white/5 text-gray-500 border border-white/10 hover:bg-pink-500/10 hover:text-pink-400 hover:border-pink-500/20"
+                          ? "bg-pink-500/20 text-pink-400 border border-pink-500/30"
+                          : "bg-surface-high text-on-surface-variant border border-outline-variant hover:bg-pink-500/10 hover:text-pink-400 hover:border-pink-500/20"
                       }`}
                       aria-label={debate.user_liked ? "Unlike debate" : "Like debate"}
                     >
@@ -217,7 +217,7 @@ export default function BrowsePage() {
 
           {/* Debate Count Footer */}
           {sorted.length > 0 && (
-            <div className="mt-8 text-center text-xs text-gray-600 font-medium">
+            <div className="mt-8 text-center text-xs text-on-surface-variant font-medium">
               {sorted.length} debate{sorted.length !== 1 ? "s" : ""} total
             </div>
           )}

--- a/frontend/src/app/browse/page.tsx
+++ b/frontend/src/app/browse/page.tsx
@@ -60,11 +60,6 @@ export default function BrowsePage() {
 
   return (
     <div className="min-h-screen bg-surface text-on-surface flex flex-col relative font-sans overflow-hidden">
-      {/* Background */}
-      <div className="absolute inset-0 pointer-events-none overflow-hidden z-0">
-        <div className="absolute -top-[20%] -left-[10%] w-[50vw] h-[50vw] bg-purple-600/10 blur-[120px] rounded-none mix-blend-screen animate-[pulse_8s_ease-in-out_infinite]" />
-        <div className="absolute top-[40%] -right-[15%] w-[60vw] h-[60vw] bg-blue-600/10 blur-[120px] rounded-none mix-blend-screen animate-[pulse_10s_ease-in-out_infinite_1s]" />
-      </div>
 
       {/* Header */}
       <header className="relative z-10 border-b border-outline-variant bg-black/40 backdrop-blur-3xl px-8 py-5 flex items-center justify-between shadow-sm">
@@ -201,8 +196,8 @@ export default function BrowsePage() {
                       onClick={(e) => { e.preventDefault(); handleLike(debate.id); }}
                       className={`shrink-0 flex flex-col items-center gap-1 px-3 py-2.5 rounded-none transition-all duration-200 ${
                         debate.user_liked
-                          ? "bg-pink-500/20 text-pink-400 border border-pink-500/30"
-                          : "bg-surface-high text-on-surface-variant border border-outline-variant hover:bg-pink-500/10 hover:text-pink-400 hover:border-pink-500/20"
+                          ? "bg-con/20 text-con border border-con/30"
+                          : "bg-surface-high text-on-surface-variant border border-outline-variant hover:bg-con/10 hover:text-con hover:border-con/20"
                       }`}
                       aria-label={debate.user_liked ? "Unlike debate" : "Like debate"}
                     >

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -52,11 +52,6 @@ export default function DashboardPage() {
 
   return (
     <div className="min-h-screen bg-surface text-on-surface flex flex-col relative font-sans overflow-hidden">
-      {/* Background */}
-      <div className="absolute inset-0 pointer-events-none overflow-hidden z-0">
-        <div className="absolute -top-[20%] -left-[10%] w-[50vw] h-[50vw] bg-purple-600/10 blur-[120px] rounded-none mix-blend-screen animate-[pulse_8s_ease-in-out_infinite]" />
-        <div className="absolute top-[40%] -right-[15%] w-[60vw] h-[60vw] bg-blue-600/10 blur-[120px] rounded-none mix-blend-screen animate-[pulse_10s_ease-in-out_infinite_1s]" />
-      </div>
 
       {/* Header */}
       <header className="relative z-10 border-b border-outline-variant bg-black/40 backdrop-blur-3xl px-8 py-5 flex items-center justify-between shadow-sm">

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -9,7 +9,7 @@ import HistoryCard from "@/components/dashboard/HistoryCard";
 export default function DashboardPage() {
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   const [userEmail, setUserEmail] = useState<string | null>(null);
-  
+
   const [debates, setDebates] = useState<DebateSummary[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -51,30 +51,30 @@ export default function DashboardPage() {
   if (!isLoggedIn) return null;
 
   return (
-    <div className="min-h-screen bg-slate-950 text-gray-100 flex flex-col relative font-sans overflow-hidden">
+    <div className="min-h-screen bg-surface text-on-surface flex flex-col relative font-sans overflow-hidden">
       {/* Background */}
       <div className="absolute inset-0 pointer-events-none overflow-hidden z-0">
-        <div className="absolute -top-[20%] -left-[10%] w-[50vw] h-[50vw] bg-purple-600/10 blur-[120px] rounded-full mix-blend-screen animate-[pulse_8s_ease-in-out_infinite]" />
-        <div className="absolute top-[40%] -right-[15%] w-[60vw] h-[60vw] bg-blue-600/10 blur-[120px] rounded-full mix-blend-screen animate-[pulse_10s_ease-in-out_infinite_1s]" />
+        <div className="absolute -top-[20%] -left-[10%] w-[50vw] h-[50vw] bg-purple-600/10 blur-[120px] rounded-none mix-blend-screen animate-[pulse_8s_ease-in-out_infinite]" />
+        <div className="absolute top-[40%] -right-[15%] w-[60vw] h-[60vw] bg-blue-600/10 blur-[120px] rounded-none mix-blend-screen animate-[pulse_10s_ease-in-out_infinite_1s]" />
       </div>
 
       {/* Header */}
-      <header className="relative z-10 border-b border-white/10 bg-black/40 backdrop-blur-3xl px-8 py-5 flex items-center justify-between shadow-sm">
+      <header className="relative z-10 border-b border-outline-variant bg-black/40 backdrop-blur-3xl px-8 py-5 flex items-center justify-between shadow-sm">
         <Link href="/" className="flex items-center gap-3 group">
-          <div className="w-8 h-8 rounded-xl bg-gradient-to-br from-cyan-400 via-blue-500 to-purple-600 flex items-center justify-center shadow-[0_0_20px_rgba(56,189,248,0.5)] group-hover:shadow-[0_0_30px_rgba(56,189,248,0.7)] transition-shadow">
-            <span className="text-white font-bold text-sm">🎯</span>
+          <div className="w-8 h-8 rounded-none bg-pro flex items-center justify-center">
+            <span className="text-[#00195b] font-bold text-sm">🎯</span>
           </div>
-          <span className="text-xl font-black tracking-tighter bg-clip-text text-transparent bg-gradient-to-r from-white to-gray-400">
+          <span className="text-xl font-black tracking-tighter text-on-surface">
             DebateMeBro
           </span>
         </Link>
         <div className="flex items-center gap-5">
           <div className="flex items-center gap-3">
-            <div className="w-8 h-8 rounded-full bg-gradient-to-br from-fuchsia-500 to-purple-600 flex items-center justify-center text-xs font-black text-white uppercase">
+            <div className="w-8 h-8 rounded-none bg-con flex items-center justify-center text-xs font-black text-[#4a0004] uppercase">
               {userEmail?.[0] || "U"}
             </div>
-            <span className="text-sm text-gray-400 hidden sm:inline">{userEmail}</span>
-            <button onClick={handleLogout} className="text-xs font-bold text-gray-500 hover:text-gray-300 transition-colors ml-2">
+            <span className="text-sm text-on-surface-variant hidden sm:inline">{userEmail}</span>
+            <button onClick={handleLogout} className="text-xs font-bold text-on-surface-variant hover:text-on-surface transition-colors ml-2">
               Logout
             </button>
           </div>
@@ -84,50 +84,50 @@ export default function DashboardPage() {
       {/* Main Content */}
       <main className="relative z-10 flex-1 px-6 py-12 max-w-5xl mx-auto w-full">
         <div className="mb-12">
-          <h1 className="text-3xl md:text-4xl font-black text-white mb-2">My Debates</h1>
-          <p className="text-gray-500">Your debate history and voting record</p>
+          <h1 className="text-3xl md:text-4xl font-black text-on-surface mb-2">My Debates</h1>
+          <p className="text-on-surface-variant">Your debate history and voting record</p>
         </div>
 
         {/* Quick Actions */}
         <div className="grid grid-cols-1 md:grid-cols-4 gap-4 mb-12">
-          <Link href="/" className="group p-6 rounded-2xl bg-gradient-to-br from-cyan-500/10 to-blue-600/10 border border-cyan-500/20 hover:border-cyan-500/40 transition-all hover:-translate-y-1">
+          <Link href="/" className="group p-6 rounded-none bg-surface-container border-l-2 border-pro border border-outline-variant hover:bg-surface-high transition-all">
             <div className="text-2xl mb-3">💡</div>
-            <div className="text-sm font-black text-white mb-1">New Debate</div>
-            <div className="text-xs text-gray-500">Pick a topic and start</div>
+            <div className="text-sm font-black text-on-surface mb-1">New Debate</div>
+            <div className="text-xs text-on-surface-variant">Pick a topic and start</div>
           </Link>
-          <Link href="/browse" className="group p-6 rounded-2xl bg-gradient-to-br from-purple-500/10 to-fuchsia-600/10 border border-purple-500/20 hover:border-purple-500/40 transition-all hover:-translate-y-1">
+          <Link href="/browse" className="group p-6 rounded-none bg-surface-container border-l-2 border-con border border-outline-variant hover:bg-surface-high transition-all">
             <div className="text-2xl mb-3">🌐</div>
-            <div className="text-sm font-black text-white mb-1">Browse All</div>
-            <div className="text-xs text-gray-500">Explore public debates</div>
+            <div className="text-sm font-black text-on-surface mb-1">Browse All</div>
+            <div className="text-xs text-on-surface-variant">Explore public debates</div>
           </Link>
-          <div className="p-6 rounded-2xl bg-white/[0.03] border border-white/10">
+          <div className="p-6 rounded-none bg-surface-container border border-outline-variant">
             <div className="text-2xl mb-3">📊</div>
-            <div className="text-sm font-black text-white mb-1">{isLoading ? "..." : debates.length}</div>
-            <div className="text-xs text-gray-500">Debates Watched</div>
+            <div className="text-sm font-black text-on-surface mb-1">{isLoading ? "..." : debates.length}</div>
+            <div className="text-xs text-on-surface-variant">Debates Watched</div>
           </div>
-          <div className="p-6 rounded-2xl bg-white/[0.03] border border-white/10">
+          <div className="p-6 rounded-none bg-surface-container border border-outline-variant">
             <div className="text-2xl mb-3">🗳️</div>
-            <div className="text-sm font-black text-white mb-1">Coming Soon</div>
-            <div className="text-xs text-gray-500">Votes Cast</div>
+            <div className="text-sm font-black text-on-surface mb-1">Coming Soon</div>
+            <div className="text-xs text-on-surface-variant">Votes Cast</div>
           </div>
         </div>
 
         {/* Debate History */}
         <div>
-          <h2 className="text-lg font-black text-white mb-6 uppercase tracking-widest">Recent Debates</h2>
+          <h2 className="text-lg font-black text-on-surface mb-6 uppercase tracking-widest">Recent Debates</h2>
 
           {isLoading ? (
             <div className="space-y-4">
               {[1, 2, 3].map((i) => (
-                <div key={i} className="animate-pulse bg-white/[0.03] border border-white/10 rounded-2xl p-6 h-32" />
+                <div key={i} className="animate-pulse bg-surface-container border border-outline-variant rounded-none p-6 h-32" />
               ))}
             </div>
           ) : error ? (
-            <div className="text-center py-20 bg-red-500/10 border border-red-500/20 rounded-2xl">
-              <p className="text-red-400 mb-4">{error}</p>
-              <button 
+            <div className="text-center py-20 bg-con/10 border border-con/30 rounded-none">
+              <p className="text-con mb-4">{error}</p>
+              <button
                 onClick={loadDebates}
-                className="px-6 py-2 bg-red-500/20 text-red-300 rounded-xl hover:bg-red-500/30 transition-colors"
+                className="px-6 py-2 bg-con/20 text-con rounded-none hover:bg-con/30 transition-colors"
               >
                 Retry
               </button>
@@ -135,8 +135,8 @@ export default function DashboardPage() {
           ) : debates.length === 0 ? (
             <div className="text-center py-20">
               <div className="text-5xl mb-4 opacity-30">🎯</div>
-              <p className="text-gray-500 text-lg mb-6">No debates yet. Start your first one!</p>
-              <Link href="/" className="inline-block px-8 py-3 bg-gradient-to-r from-cyan-500 to-blue-600 text-white rounded-xl font-bold transition-all hover:shadow-[0_0_30px_rgba(6,182,212,0.4)]">
+              <p className="text-on-surface-variant text-lg mb-6">No debates yet. Start your first one!</p>
+              <Link href="/" className="inline-block bg-pro text-[#00195b] rounded-none uppercase tracking-widest px-6 py-3 font-bold transition-all">
                 Start a Debate →
               </Link>
             </div>

--- a/frontend/src/app/debates/[id]/page.tsx
+++ b/frontend/src/app/debates/[id]/page.tsx
@@ -585,18 +585,17 @@ export default function DebatePage() {
     setStreaming(true);
 
     const wait = (ms: number) => new Promise<void>((resolve) => {
-      let check: ReturnType<typeof setInterval>;
-      const t = setTimeout(() => {
-        clearInterval(check);
-        resolve();
-      }, ms);
-      check = setInterval(() => {
+      const check = setInterval(() => {
         if (mockAbortRef.current) {
           clearTimeout(t);
           clearInterval(check);
           resolve();
         }
       }, 100);
+      const t = setTimeout(() => {
+        clearInterval(check);
+        resolve();
+      }, ms);
     });
 
     for (const step of MOCK_PHASE_SEQUENCE) {

--- a/frontend/src/app/debates/[id]/page.tsx
+++ b/frontend/src/app/debates/[id]/page.tsx
@@ -1355,7 +1355,7 @@ export default function DebatePage() {
                     <div className="text-5xl mb-4">📊</div>
                     <h2 className="text-2xl font-headline font-black text-on-surface mb-2">Judging Results</h2>
                     <div className={`inline-block px-6 py-2 rounded-none text-sm font-black uppercase tracking-widest mt-2 ${rawWinner === "pro" ? "bg-pro/20 text-pro border border-pro/30" : rawWinner === "con" ? "bg-con/20 text-con border border-con/30" : "bg-surface-high text-on-surface-variant border border-outline-variant"}`}>
-                      {debateWinner} wins — {proTotal.toFixed(2)} vs {conTotal.toFixed(2)}
+                      {rawWinner === "tie" ? "It's a Tie" : `${debateWinner} wins`} — {proTotal.toFixed(2)} vs {conTotal.toFixed(2)}
                     </div>
                   </div>
 
@@ -1385,7 +1385,7 @@ export default function DebatePage() {
                   {judgeVerdict && (
                     <div className="p-6 rounded-none bg-surface-container border border-outline-variant shadow-lg mb-8">
                       <div className="text-xs text-on-surface-variant mb-3 uppercase tracking-widest font-black">AI Judges Verdict</div>
-                      <p className="text-sm text-on-surface leading-relaxed"><strong className="text-on-surface">{debateWinner} wins.</strong> {judgeVerdict.summary}</p>
+                      <p className="text-sm text-on-surface leading-relaxed"><strong className="text-on-surface">{rawWinner === "tie" ? "It's a Tie." : `${debateWinner} wins.`}</strong> {judgeVerdict.summary}</p>
                     </div>
                   )}
 

--- a/frontend/src/app/debates/[id]/page.tsx
+++ b/frontend/src/app/debates/[id]/page.tsx
@@ -246,18 +246,18 @@ function ResearchDocModal({ side, topicId, onClose }: { side: "pro" | "con"; top
       if (match.index > lastIndex) {
         // `escaped` is already HTML-sanitized; bold captures from it are safe
         const escaped = escapeHtml(text.slice(lastIndex, match.index));
-        parts.push(escaped.replace(/\*\*([^*]+)\*\*/g, (_, inner) => `<strong class="text-gray-200 font-bold">${inner}</strong>`));
+        parts.push(escaped.replace(/\*\*([^*]+)\*\*/g, (_, inner) => `<strong class="text-on-surface font-bold">${inner}</strong>`));
       }
       const safeUrl = sanitizeMdUrl(match[2]);
       parts.push(
-        `<a href="${safeUrl}" target="_blank" rel="noopener noreferrer" class="text-emerald-400 hover:text-emerald-300 underline underline-offset-2 decoration-emerald-500/40 hover:decoration-emerald-400 transition-colors">${escapeHtml(match[1])}</a>`
+        `<a href="${safeUrl}" target="_blank" rel="noopener noreferrer" class="text-pro hover:text-pro/80 underline underline-offset-2 decoration-pro/40 hover:decoration-pro/60 transition-colors">${escapeHtml(match[1])}</a>`
       );
       lastIndex = linkRegex.lastIndex;
     }
     if (lastIndex < text.length) {
       // `escaped` is already HTML-sanitized; bold captures from it are safe
       const escaped = escapeHtml(text.slice(lastIndex));
-      parts.push(escaped.replace(/\*\*([^*]+)\*\*/g, (_, inner) => `<strong class="text-gray-200 font-bold">${inner}</strong>`));
+      parts.push(escaped.replace(/\*\*([^*]+)\*\*/g, (_, inner) => `<strong class="text-on-surface font-bold">${inner}</strong>`));
     }
     return parts.join("");
   }
@@ -268,10 +268,10 @@ function ResearchDocModal({ side, topicId, onClose }: { side: "pro" | "con"; top
       .split("\n")
       .map((line) => {
         // Headings
-        if (line.startsWith("### ")) return `<h3 class="text-base font-bold text-gray-200 mt-6 mb-2">${escapeHtml(line.slice(4))}</h3>`;
-        if (line.startsWith("## ")) return `<h2 class="text-lg font-black text-white mt-10 mb-3 pb-2 border-b border-white/10">${escapeHtml(line.slice(3))}</h2>`;
-        if (line.startsWith("# ")) return `<h1 class="text-2xl font-black text-white mt-8 mb-4">${escapeHtml(line.slice(2))}</h1>`;
-        if (line.startsWith("---")) return `<hr class="border-white/10 my-8" />`;
+        if (line.startsWith("### ")) return `<h3 class="text-base font-bold text-on-surface mt-6 mb-2">${escapeHtml(line.slice(4))}</h3>`;
+        if (line.startsWith("## ")) return `<h2 class="text-lg font-black text-on-surface mt-10 mb-3 pb-2 border-b border-outline-variant">${escapeHtml(line.slice(3))}</h2>`;
+        if (line.startsWith("# ")) return `<h1 class="text-2xl font-black text-on-surface mt-8 mb-4">${escapeHtml(line.slice(2))}</h1>`;
+        if (line.startsWith("---")) return `<hr class="border-outline-variant my-8" />`;
         if (line.trim() === "") return `<div class="h-3"></div>`;
 
         // List items
@@ -279,12 +279,12 @@ function ResearchDocModal({ side, topicId, onClose }: { side: "pro" | "con"; top
         if (processed.startsWith("- ")) {
           processed = processed.slice(2);
           processed = inlineFormat(processed);
-          return `<div class="flex items-start gap-2 mb-2 ml-1"><span class="text-emerald-500 mt-1 shrink-0">•</span><span class="text-sm text-gray-400 leading-relaxed">${processed}</span></div>`;
+          return `<div class="flex items-start gap-2 mb-2 ml-1"><span class="text-pro mt-1 shrink-0">•</span><span class="text-sm text-on-surface-variant leading-relaxed">${processed}</span></div>`;
         }
 
         // Regular paragraphs
         processed = inlineFormat(processed);
-        return `<p class="text-sm text-gray-400 leading-relaxed mb-3">${processed}</p>`;
+        return `<p class="text-sm text-on-surface-variant leading-relaxed mb-3">${processed}</p>`;
       })
       .join("\n");
   };
@@ -296,32 +296,32 @@ function ResearchDocModal({ side, topicId, onClose }: { side: "pro" | "con"; top
 
       {/* Modal container */}
       <div
-        className={`relative w-full max-w-6xl max-h-full rounded-3xl border-2 shadow-[0_0_80px_rgba(0,0,0,0.8)] flex flex-col overflow-hidden ${
-          isPro ? "border-cyan-500/30 bg-[#0a0f1a]" : "border-fuchsia-500/30 bg-[#0a0f1a]"
+        className={`relative w-full max-w-6xl max-h-full rounded-none border-2 flex flex-col overflow-hidden ${
+          isPro ? "border-pro/30 bg-surface-container" : "border-con/30 bg-surface-container"
         }`}
       >
         {/* Sticky Header */}
         <div className={`px-6 lg:px-8 py-4 border-b flex items-center justify-between shrink-0 ${
-          isPro ? "border-cyan-500/20 bg-cyan-950/40" : "border-fuchsia-500/20 bg-fuchsia-950/40"
+          isPro ? "border-pro/20 bg-pro/10" : "border-con/20 bg-con/10"
         }`}>
           <div className="flex items-center gap-3">
-            <div className={`w-10 h-10 rounded-xl flex items-center justify-center text-sm font-black text-white shadow-lg ${
-              isPro ? "bg-gradient-to-br from-cyan-400 to-blue-600" : "bg-gradient-to-br from-fuchsia-400 to-purple-600"
+            <div className={`w-10 h-10 rounded-none flex items-center justify-center text-sm font-black text-white ${
+              isPro ? "bg-pro" : "bg-con"
             }`}>{isPro ? "P" : "C"}</div>
             <div>
-              <div className={`text-sm font-black uppercase tracking-widest ${isPro ? "text-cyan-400" : "text-fuchsia-400"}`}>
+              <div className={`text-sm font-black uppercase tracking-widest ${isPro ? "text-pro" : "text-con"}`}>
                 {isPro ? "Pro" : "Con"} Research Document
               </div>
-              <div className="text-xs text-gray-500 font-mono">healthcare/{side}_research.md</div>
+              <div className="text-xs text-on-surface-variant font-mono">healthcare/{side}_research.md</div>
             </div>
           </div>
           <button
             type="button"
             onClick={(e) => { e.preventDefault(); e.stopPropagation(); onClose(); }}
-            className={`w-10 h-10 rounded-xl flex items-center justify-center transition-all text-lg font-bold cursor-pointer ${
+            className={`w-10 h-10 rounded-none flex items-center justify-center transition-all text-lg font-bold cursor-pointer ${
               isPro
-                ? "bg-cyan-500/10 hover:bg-cyan-500/30 text-cyan-400 border border-cyan-500/30"
-                : "bg-fuchsia-500/10 hover:bg-fuchsia-500/30 text-fuchsia-400 border border-fuchsia-500/30"
+                ? "bg-pro/10 hover:bg-pro/30 text-pro border border-pro/30"
+                : "bg-con/10 hover:bg-con/30 text-con border border-con/30"
             }`}
           >
             ×
@@ -332,7 +332,7 @@ function ResearchDocModal({ side, topicId, onClose }: { side: "pro" | "con"; top
         <div className="flex-1 overflow-y-auto px-6 lg:px-10 py-8">
           {loading ? (
             <div className="flex items-center justify-center h-40">
-              <div className="w-8 h-8 rounded-full border-2 border-purple-400 border-t-transparent animate-spin" />
+              <div className="w-8 h-8 rounded-none border-2 border-pro border-t-transparent animate-spin" />
             </div>
           ) : (
             <div
@@ -344,13 +344,13 @@ function ResearchDocModal({ side, topicId, onClose }: { side: "pro" | "con"; top
 
         {/* Footer */}
         <div className={`px-6 lg:px-8 py-3 border-t flex items-center justify-between shrink-0 ${
-          isPro ? "border-cyan-500/10 bg-cyan-950/20" : "border-fuchsia-500/10 bg-fuchsia-950/20"
+          isPro ? "border-pro/10 bg-pro/10" : "border-con/10 bg-con/10"
         }`}>
-          <span className="text-xs text-gray-600">{content.split("\n").length} lines • {(content.length / 1024).toFixed(0)} KB</span>
+          <span className="text-xs text-on-surface-variant">{content.split("\n").length} lines • {(content.length / 1024).toFixed(0)} KB</span>
           <button
             type="button"
             onClick={(e) => { e.preventDefault(); e.stopPropagation(); onClose(); }}
-            className="px-5 py-2 text-xs font-black uppercase tracking-widest bg-white/5 hover:bg-white/10 text-gray-400 hover:text-white rounded-xl border border-white/10 transition-all"
+            className="px-5 py-2 text-xs font-black uppercase tracking-widest bg-surface-high hover:bg-surface-bright text-on-surface-variant hover:text-on-surface rounded-none border border-outline-variant transition-all"
           >
             Close
           </button>
@@ -364,36 +364,35 @@ function ResearchDocModal({ side, topicId, onClose }: { side: "pro" | "con"; top
 function ResearchCard({ side, sections }: { side: "pro" | "con"; sections: typeof MOCK_PRO_RESEARCH }) {
   const [expanded, setExpanded] = useState<number | null>(null);
   const isPro = side === "pro";
-  const accentText = isPro ? "text-cyan-400" : "text-fuchsia-400";
-  const accentBorder = isPro ? "border-cyan-500/20" : "border-fuchsia-500/20";
-  const accentBg = isPro ? "bg-cyan-500/5" : "bg-fuchsia-500/5";
-  const dotColor = isPro ? "bg-cyan-400" : "bg-fuchsia-400";
+  const accentText = isPro ? "text-pro" : "text-con";
+  const accentBorder = isPro ? "border-pro/20" : "border-con/20";
+  const dotColor = isPro ? "bg-pro" : "bg-con";
 
   return (
     <div className="space-y-3">
       {sections.map((section, i) => (
-        <div key={i} className={`rounded-2xl border ${accentBorder} ${accentBg} backdrop-blur-xl overflow-hidden transition-all`}>
-          <button onClick={() => setExpanded(expanded === i ? null : i)} className="w-full text-left px-5 py-4 flex items-center gap-3 hover:bg-white/[0.02] transition-colors">
-            <span className={`w-2 h-2 rounded-full ${dotColor} shrink-0`} />
-            <span className="font-bold text-sm text-gray-200 flex-1">{section.title}</span>
-            <span className="text-gray-500 text-xs">{section.keyStats.length} key stats</span>
+        <div key={i} className={`rounded-none border-l-2 ${accentBorder} bg-surface-container overflow-hidden transition-all`}>
+          <button onClick={() => setExpanded(expanded === i ? null : i)} className="w-full text-left px-5 py-4 flex items-center gap-3 hover:bg-surface-high transition-colors">
+            <span className={`w-2 h-2 rounded-none ${dotColor} shrink-0`} />
+            <span className="font-bold text-sm text-on-surface flex-1">{section.title}</span>
+            <span className="text-on-surface-variant text-xs">{section.keyStats.length} key stats</span>
             <span className={`text-xs transition-transform ${expanded === i ? "rotate-180" : ""}`}>▼</span>
           </button>
           {expanded === i && (
-            <div className="px-5 pb-5 space-y-3 border-t border-white/[0.04]">
+            <div className="px-5 pb-5 space-y-3 border-t border-outline-variant">
               <div className="pt-4 space-y-2">
                 {section.keyStats.map((stat, j) => (
                   <div key={j} className="flex items-start gap-2 text-sm">
                     <span className={`${accentText} mt-0.5 shrink-0`}>→</span>
-                    <span className="text-gray-300">{stat}</span>
+                    <span className="text-on-surface-variant">{stat}</span>
                   </div>
                 ))}
               </div>
-              <div className="pt-3 border-t border-white/[0.04]">
-                <div className="text-xs text-gray-500 font-bold uppercase tracking-widest mb-2">Sources</div>
+              <div className="pt-3 border-t border-outline-variant">
+                <div className="text-xs text-on-surface-variant font-bold uppercase tracking-widest mb-2">Sources</div>
                 {section.sources.map((src, j) => (
-                  <div key={j} className="text-xs text-gray-500 flex gap-2 mb-1">
-                    <span className="text-emerald-600">📄</span>
+                  <div key={j} className="text-xs text-on-surface-variant flex gap-2 mb-1">
+                    <span className="text-pro">📄</span>
                     <span>{src}</span>
                   </div>
                 ))}
@@ -443,48 +442,46 @@ function normalizeScores(raw: Record<string, Record<string, number>> | undefined
 function PersonaCard({ persona, side, position }: { persona: Persona; side: "pro" | "con"; position: string }) {
   const [open, setOpen] = useState(false);
   const isPro = side === "pro";
-  const iconBg = isPro ? "bg-gradient-to-br from-cyan-400 to-blue-600" : "bg-gradient-to-br from-fuchsia-400 to-purple-600";
-  const iconShadow = isPro ? "shadow-[0_0_20px_rgba(6,182,212,0.3)]" : "shadow-[0_0_20px_rgba(217,70,239,0.3)]";
-  const borderColor = isPro ? "border-cyan-500/20" : "border-fuchsia-500/20";
-  const bgColor = isPro ? "bg-cyan-950/20" : "bg-fuchsia-950/20";
-  const labelColor = isPro ? "text-cyan-400" : "text-fuchsia-400";
-  const tagBg = isPro ? "bg-cyan-500/10 text-cyan-300 border-cyan-500/20" : "bg-fuchsia-500/10 text-fuchsia-300 border-fuchsia-500/20";
+  const iconBg = isPro ? "bg-pro" : "bg-con";
+  const borderColor = isPro ? "border-pro" : "border-con";
+  const labelColor = isPro ? "text-pro" : "text-con";
+  const tagBg = isPro ? "bg-pro/10 text-pro border-pro/20" : "bg-con/10 text-con border-con/20";
   const align = isPro ? "text-left" : "text-right";
   return (
-    <div className={`rounded-2xl border ${borderColor} ${bgColor} overflow-hidden transition-all`}>
-      <button onClick={() => setOpen(!open)} className={`w-full px-5 py-4 flex items-center gap-4 hover:bg-white/[0.02] transition-colors ${!isPro ? "flex-row-reverse" : ""}`}>
-        <div className={`w-12 h-12 rounded-2xl ${iconBg} ${iconShadow} flex items-center justify-center text-lg font-black text-white shrink-0`}>{isPro ? "P" : "C"}</div>
+    <div className={`rounded-none border-l-4 ${borderColor} bg-surface-container overflow-hidden transition-all`}>
+      <button onClick={() => setOpen(!open)} className={`w-full px-5 py-4 flex items-center gap-4 hover:bg-surface-high transition-colors ${!isPro ? "flex-row-reverse" : ""}`}>
+        <div className={`w-12 h-12 rounded-none ${iconBg} flex items-center justify-center text-lg font-black text-white shrink-0`}>{isPro ? "P" : "C"}</div>
         <div className={`min-w-0 flex-1 ${align}`}>
           <div className={`text-xs font-black uppercase tracking-widest ${labelColor} mb-0.5`}>{isPro ? "Pro" : "Con"}</div>
-          <div className="font-black text-white text-base truncate">{persona.name}</div>
-          <div className="text-sm text-gray-400 truncate">{persona.role}</div>
+          <div className="font-black text-on-surface text-base truncate">{persona.name}</div>
+          <div className="text-sm text-on-surface-variant truncate">{persona.role}</div>
         </div>
-        <span className={`text-xs text-gray-500 transition-transform shrink-0 ${open ? "rotate-180" : ""}`}>▼</span>
+        <span className={`text-xs text-on-surface-variant transition-transform shrink-0 ${open ? "rotate-180" : ""}`}>▼</span>
       </button>
       {open && (
-        <div className={`px-5 pb-5 pt-3 border-t border-white/[0.06] space-y-3 ${align}`}>
+        <div className={`px-5 pb-5 pt-3 border-t border-outline-variant space-y-3 ${align}`}>
           {position && (
             <div>
-              <div className={`text-xs font-black uppercase tracking-widest text-gray-500 mb-1`}>Position</div>
-              <p className="text-sm text-gray-300 leading-relaxed">{position}</p>
+              <div className={`text-xs font-black uppercase tracking-widest text-on-surface-variant mb-1`}>Position</div>
+              <p className="text-sm text-on-surface-variant leading-relaxed">{position}</p>
             </div>
           )}
           {persona.expertise_areas && persona.expertise_areas.length > 0 && (
             <div>
-              <div className="text-xs font-black uppercase tracking-widest text-gray-500 mb-1.5">Expertise</div>
-              <div className={`flex flex-wrap gap-1.5 ${!isPro ? "justify-end" : ""}`}>{persona.expertise_areas.map((e, i) => <span key={i} className={`text-xs px-2.5 py-1 rounded-full border ${tagBg}`}>{e}</span>)}</div>
+              <div className="text-xs font-black uppercase tracking-widest text-on-surface-variant mb-1.5">Expertise</div>
+              <div className={`flex flex-wrap gap-1.5 ${!isPro ? "justify-end" : ""}`}>{persona.expertise_areas.map((e, i) => <span key={i} className={`text-xs px-2.5 py-1 rounded-none border ${tagBg}`}>{e}</span>)}</div>
             </div>
           )}
           {persona.core_values && persona.core_values.length > 0 && (
             <div>
-              <div className="text-xs font-black uppercase tracking-widest text-gray-500 mb-1.5">Core Values</div>
-              <div className={`flex flex-wrap gap-1.5 ${!isPro ? "justify-end" : ""}`}>{persona.core_values.map((v, i) => <span key={i} className={`text-xs px-2.5 py-1 rounded-full border ${tagBg}`}>{v}</span>)}</div>
+              <div className="text-xs font-black uppercase tracking-widest text-on-surface-variant mb-1.5">Core Values</div>
+              <div className={`flex flex-wrap gap-1.5 ${!isPro ? "justify-end" : ""}`}>{persona.core_values.map((v, i) => <span key={i} className={`text-xs px-2.5 py-1 rounded-none border ${tagBg}`}>{v}</span>)}</div>
             </div>
           )}
           {persona.rhetorical_approach && (
             <div>
-              <div className="text-xs font-black uppercase tracking-widest text-gray-500 mb-1">Approach</div>
-              <p className="text-sm text-gray-400 leading-relaxed">{persona.rhetorical_approach}</p>
+              <div className="text-xs font-black uppercase tracking-widest text-on-surface-variant mb-1">Approach</div>
+              <p className="text-sm text-on-surface-variant leading-relaxed">{persona.rhetorical_approach}</p>
             </div>
           )}
         </div>
@@ -1072,12 +1069,12 @@ export default function DebatePage() {
           <div className="flex items-center gap-3">
             {isDemoMode
               ? <span className="text-[10px] font-bold text-amber-400 uppercase tracking-widest bg-amber-900/30 px-2.5 py-1 rounded-none border border-amber-500/30">Demo</span>
-              : <span className="text-[10px] font-bold text-sky-400 uppercase tracking-widest bg-sky-900/30 px-2.5 py-1 rounded-none border border-sky-500/30">Live</span>
+              : <span className="text-[10px] font-bold text-on-surface uppercase tracking-widest bg-surface-container px-2.5 py-1 rounded-none border border-outline-variant">Live</span>
             }
-            {isFromCache && <span className="text-[10px] font-bold text-violet-400 uppercase tracking-widest bg-violet-900/30 px-2.5 py-1 rounded-none border border-violet-500/30">Cached</span>}
+            {isFromCache && <span className="text-[10px] font-bold text-on-surface-variant uppercase tracking-widest bg-surface-container px-2.5 py-1 rounded-none border border-outline-variant">Cached</span>}
             {isStreaming ? (
-              <span className="flex items-center gap-2 text-[10px] font-bold text-emerald-400 uppercase tracking-widest bg-emerald-900/30 px-2.5 py-1 rounded-none border border-emerald-500/30 shadow-[0_0_10px_rgba(52,211,153,0.2)]">
-                <span className="w-1.5 h-1.5 bg-emerald-400 rounded-none animate-pulse shadow-[0_0_6px_rgba(52,211,153,0.8)]" /> Live
+              <span className="flex items-center gap-2 text-[10px] font-bold text-pro uppercase tracking-widest bg-pro/10 px-2.5 py-1 rounded-none border border-pro/30">
+                <span className="w-1.5 h-1.5 bg-pro rounded-none animate-pulse" /> Live
               </span>
             ) : (
               <span className="text-[10px] font-bold text-on-surface-variant uppercase tracking-widest bg-surface-container px-2.5 py-1 rounded-none border border-outline-variant">
@@ -1116,65 +1113,65 @@ export default function DebatePage() {
           <div className="max-w-5xl w-full mx-4 animate-[fadeIn_0.5s_ease-out]">
             <div className="text-center mb-8">
               <div className="text-5xl mb-3">⚔️</div>
-              <h2 className="text-3xl font-black text-white mb-2 tracking-tight">Meet Your Debaters</h2>
-              <p className="text-sm text-gray-400 font-medium">Two AI advocates have been generated for this debate. Review their profiles, then start the debate.</p>
+              <h2 className="text-3xl font-headline font-black text-on-surface mb-2 tracking-tight">Meet Your Debaters</h2>
+              <p className="text-sm text-on-surface-variant font-medium">Two AI advocates have been generated for this debate. Review their profiles, then start the debate.</p>
             </div>
             <div className="grid md:grid-cols-2 gap-6 mb-8">
               {/* Pro Persona Card */}
-              <div className="p-6 rounded-[2rem] bg-gradient-to-b from-cyan-950/40 to-slate-950/80 border border-cyan-500/20 shadow-[0_0_40px_rgba(6,182,212,0.1)] animate-[slideUp_0.6s_ease-out]">
+              <div className="p-6 rounded-none bg-surface-container border-l-4 border-pro animate-[slideUp_0.6s_ease-out]">
                 <div className="flex items-center gap-4 mb-4">
-                  <div className="w-14 h-14 rounded-2xl bg-gradient-to-br from-cyan-400 to-blue-600 flex items-center justify-center text-xl font-black text-white shadow-lg">P</div>
+                  <div className="w-14 h-14 rounded-none bg-pro flex items-center justify-center text-xl font-black text-white">P</div>
                   <div>
-                    <div className="text-xs font-black uppercase tracking-widest text-cyan-400">Pro</div>
-                    <div className="font-black text-white text-lg">{proPersona.name}</div>
-                    <div className="text-xs text-gray-400">{proPersona.role}</div>
+                    <div className="text-xs font-black uppercase tracking-widest text-pro">Pro</div>
+                    <div className="font-black text-on-surface text-lg">{proPersona.name}</div>
+                    <div className="text-xs text-on-surface-variant">{proPersona.role}</div>
                   </div>
                 </div>
                 {proPersona.expertise_areas && proPersona.expertise_areas.length > 0 && (
                   <div className="mb-3">
-                    <div className="text-[10px] font-black uppercase tracking-widest text-gray-500 mb-1.5">Expertise</div>
-                    <div className="flex flex-wrap gap-1.5">{proPersona.expertise_areas.map((e, i) => <span key={i} className="text-[10px] px-2 py-0.5 rounded-full bg-cyan-500/10 text-cyan-300 border border-cyan-500/20">{e}</span>)}</div>
+                    <div className="text-[10px] font-black uppercase tracking-widest text-on-surface-variant mb-1.5">Expertise</div>
+                    <div className="flex flex-wrap gap-1.5">{proPersona.expertise_areas.map((e, i) => <span key={i} className="text-[10px] px-2 py-0.5 rounded-none bg-pro/10 text-pro border border-pro/20">{e}</span>)}</div>
                   </div>
                 )}
                 {proPersona.core_values && proPersona.core_values.length > 0 && (
                   <div className="mb-3">
-                    <div className="text-[10px] font-black uppercase tracking-widest text-gray-500 mb-1.5">Core Values</div>
-                    <div className="flex flex-wrap gap-1.5">{proPersona.core_values.map((v, i) => <span key={i} className="text-[10px] px-2 py-0.5 rounded-full bg-blue-500/10 text-blue-300 border border-blue-500/20">{v}</span>)}</div>
+                    <div className="text-[10px] font-black uppercase tracking-widest text-on-surface-variant mb-1.5">Core Values</div>
+                    <div className="flex flex-wrap gap-1.5">{proPersona.core_values.map((v, i) => <span key={i} className="text-[10px] px-2 py-0.5 rounded-none bg-pro/10 text-pro border border-pro/20">{v}</span>)}</div>
                   </div>
                 )}
                 {proPersona.rhetorical_approach && (
                   <div>
-                    <div className="text-[10px] font-black uppercase tracking-widest text-gray-500 mb-1">Approach</div>
-                    <p className="text-xs text-gray-400 leading-relaxed">{proPersona.rhetorical_approach}</p>
+                    <div className="text-[10px] font-black uppercase tracking-widest text-on-surface-variant mb-1">Approach</div>
+                    <p className="text-xs text-on-surface-variant leading-relaxed">{proPersona.rhetorical_approach}</p>
                   </div>
                 )}
               </div>
               {/* Con Persona Card */}
-              <div className="p-6 rounded-[2rem] bg-gradient-to-b from-fuchsia-950/40 to-slate-950/80 border border-fuchsia-500/20 shadow-[0_0_40px_rgba(217,70,239,0.1)] animate-[slideUp_0.6s_ease-out_0.15s_both]">
+              <div className="p-6 rounded-none bg-surface-container border-l-4 border-con animate-[slideUp_0.6s_ease-out_0.15s_both]">
                 <div className="flex items-center gap-4 mb-4">
-                  <div className="w-14 h-14 rounded-2xl bg-gradient-to-br from-fuchsia-400 to-purple-600 flex items-center justify-center text-xl font-black text-white shadow-lg">C</div>
+                  <div className="w-14 h-14 rounded-none bg-con flex items-center justify-center text-xl font-black text-white">C</div>
                   <div>
-                    <div className="text-xs font-black uppercase tracking-widest text-fuchsia-400">Con</div>
-                    <div className="font-black text-white text-lg">{conPersona.name}</div>
-                    <div className="text-xs text-gray-400">{conPersona.role}</div>
+                    <div className="text-xs font-black uppercase tracking-widest text-con">Con</div>
+                    <div className="font-black text-on-surface text-lg">{conPersona.name}</div>
+                    <div className="text-xs text-on-surface-variant">{conPersona.role}</div>
                   </div>
                 </div>
                 {conPersona.expertise_areas && conPersona.expertise_areas.length > 0 && (
                   <div className="mb-3">
-                    <div className="text-[10px] font-black uppercase tracking-widest text-gray-500 mb-1.5">Expertise</div>
-                    <div className="flex flex-wrap gap-1.5">{conPersona.expertise_areas.map((e, i) => <span key={i} className="text-[10px] px-2 py-0.5 rounded-full bg-fuchsia-500/10 text-fuchsia-300 border border-fuchsia-500/20">{e}</span>)}</div>
+                    <div className="text-[10px] font-black uppercase tracking-widest text-on-surface-variant mb-1.5">Expertise</div>
+                    <div className="flex flex-wrap gap-1.5">{conPersona.expertise_areas.map((e, i) => <span key={i} className="text-[10px] px-2 py-0.5 rounded-none bg-con/10 text-con border border-con/20">{e}</span>)}</div>
                   </div>
                 )}
                 {conPersona.core_values && conPersona.core_values.length > 0 && (
                   <div className="mb-3">
-                    <div className="text-[10px] font-black uppercase tracking-widest text-gray-500 mb-1.5">Core Values</div>
-                    <div className="flex flex-wrap gap-1.5">{conPersona.core_values.map((v, i) => <span key={i} className="text-[10px] px-2 py-0.5 rounded-full bg-purple-500/10 text-purple-300 border border-purple-500/20">{v}</span>)}</div>
+                    <div className="text-[10px] font-black uppercase tracking-widest text-on-surface-variant mb-1.5">Core Values</div>
+                    <div className="flex flex-wrap gap-1.5">{conPersona.core_values.map((v, i) => <span key={i} className="text-[10px] px-2 py-0.5 rounded-none bg-con/10 text-con border border-con/20">{v}</span>)}</div>
                   </div>
                 )}
                 {conPersona.rhetorical_approach && (
                   <div>
-                    <div className="text-[10px] font-black uppercase tracking-widest text-gray-500 mb-1">Approach</div>
-                    <p className="text-xs text-gray-400 leading-relaxed">{conPersona.rhetorical_approach}</p>
+                    <div className="text-[10px] font-black uppercase tracking-widest text-on-surface-variant mb-1">Approach</div>
+                    <p className="text-xs text-on-surface-variant leading-relaxed">{conPersona.rhetorical_approach}</p>
                   </div>
                 )}
               </div>
@@ -1186,7 +1183,7 @@ export default function DebatePage() {
                   setPersonaRevealed(true);
                   handleContinue();
                 }}
-                className="px-10 py-4 text-sm font-black uppercase tracking-widest bg-gradient-to-r from-purple-600 to-blue-600 hover:from-purple-500 hover:to-blue-500 text-white rounded-2xl border border-white/20 shadow-[0_0_40px_rgba(168,85,247,0.4)] transition-all hover:scale-105 hover:shadow-[0_0_60px_rgba(168,85,247,0.6)]"
+                className="px-10 py-4 text-sm font-black uppercase tracking-widest bg-pro text-white rounded-none border border-pro/40 transition-all hover:bg-pro/80"
               >Start Debate →</button>
             </div>
           </div>
@@ -1239,9 +1236,9 @@ export default function DebatePage() {
                   <div className="max-w-md mx-auto space-y-3 text-left">
                     {MOCK_RESEARCH_STEPS.slice(0, researchStepIdx).map((step, i) => (
                       <div key={i} className="flex items-center gap-3 text-sm p-3 rounded-none bg-surface-container border border-outline-variant">
-                        <span className="text-purple-400">🔍</span>
+                        <span className="text-pro">🔍</span>
                         <span className="text-on-surface flex-1">{step.query}</span>
-                        <span className="text-emerald-400 font-mono font-bold text-xs">{step.results}</span>
+                        <span className="text-pro font-mono font-bold text-xs">{step.results}</span>
                       </div>
                     ))}
                     {researchStepIdx < MOCK_RESEARCH_STEPS.length && (

--- a/frontend/src/app/debates/[id]/page.tsx
+++ b/frontend/src/app/debates/[id]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState, useCallback } from "react";
+import Link from "next/link";
 import { useParams, useSearchParams } from "next/navigation";
 import { useDebateStore, Persona, JudgeResult, CriterionScore } from "@/lib/store";
 import { useShallow } from "zustand/shallow";
@@ -1031,8 +1032,8 @@ export default function DebatePage() {
       const tally = await castVote(id, side, token);
       setVoteTally(tally);
       setUserVote(side);
-    } catch (e: any) {
-      alert(e.message || "Failed to cast vote.");
+    } catch (e: unknown) {
+      alert(e instanceof Error ? e.message : "Failed to cast vote.");
     } finally {
       setIsVoting(false);
     }
@@ -1063,9 +1064,9 @@ export default function DebatePage() {
       <header className="relative z-30 border-b border-outline-variant bg-surface-low">
         {/* Top bar */}
         <div className="px-6 py-3 flex items-center justify-between">
-          <a href="/" className="hover:opacity-80 transition-opacity">
+          <Link href="/" className="hover:opacity-80 transition-opacity">
             <span className="text-lg font-headline font-black tracking-tighter text-on-surface">DebateMeBro</span>
-          </a>
+          </Link>
           <div className="flex items-center gap-3">
             {isDemoMode
               ? <span className="text-[10px] font-bold text-amber-400 uppercase tracking-widest bg-amber-900/30 px-2.5 py-1 rounded-none border border-amber-500/30">Demo</span>

--- a/frontend/src/app/debates/[id]/page.tsx
+++ b/frontend/src/app/debates/[id]/page.tsx
@@ -21,15 +21,15 @@ function ScoreBar({ label, weight, proScore, conScore }: { label: string; weight
   return (
     <div className="mb-5">
       <div className="flex justify-between text-xs mb-2">
-        <span className="text-gray-400 font-bold uppercase tracking-widest">{label} <span className="text-gray-600">({weight})</span></span>
-        <span className="font-mono font-black"><span className="text-cyan-400">{proScore}</span> vs <span className="text-fuchsia-400">{conScore}</span></span>
+        <span className="text-on-surface-variant font-bold uppercase tracking-widest">{label} <span className="text-on-surface-variant">({weight})</span></span>
+        <span className="font-mono font-black"><span className="text-pro">{proScore}</span> vs <span className="text-con">{conScore}</span></span>
       </div>
-      <div className="flex gap-1 h-3 rounded-full overflow-hidden">
-        <div className="flex-1 bg-slate-800 rounded-l-full overflow-hidden flex justify-end">
-          <div className="bg-gradient-to-l from-cyan-400 to-cyan-600 transition-all duration-1000 rounded-l-full" style={{ width: `${Math.min(proScore * 20, 100)}%` }} />
+      <div className="flex gap-1 h-3 rounded-none overflow-hidden">
+        <div className="flex-1 bg-surface-high rounded-none overflow-hidden flex justify-end">
+          <div className="bg-pro transition-all duration-1000 rounded-none" style={{ width: `${Math.min(proScore * 20, 100)}%` }} />
         </div>
-        <div className="flex-1 bg-slate-800 rounded-r-full overflow-hidden">
-          <div className="bg-gradient-to-r from-fuchsia-400 to-fuchsia-600 transition-all duration-1000 rounded-r-full" style={{ width: `${Math.min(conScore * 20, 100)}%` }} />
+        <div className="flex-1 bg-surface-high rounded-none overflow-hidden">
+          <div className="bg-con transition-all duration-1000 rounded-none" style={{ width: `${Math.min(conScore * 20, 100)}%` }} />
         </div>
       </div>
     </div>
@@ -58,97 +58,97 @@ function JudgeCard({ judge }: { judge: JudgeResult }) {
     "Engagement Judge": "Evaluates refutation strength, steelmanning quality, and direct engagement with opposing points",
   };
   const description = descMap[name] || "";
-  const winnerColor = winner === "pro" ? "text-cyan-400" : winner === "con" ? "text-fuchsia-400" : "text-gray-400";
-  const winnerBg = winner === "pro" ? "bg-cyan-900/30 border-cyan-500/30" : winner === "con" ? "bg-fuchsia-900/30 border-fuchsia-500/30" : "bg-gray-800/30 border-gray-500/30";
+  const winnerColor = winner === "pro" ? "text-pro" : winner === "con" ? "text-con" : "text-on-surface-variant";
+  const winnerBg = winner === "pro" ? "bg-pro/10 border-pro/30" : winner === "con" ? "bg-con/10 border-con/30" : "bg-surface-high border-outline-variant";
 
   return (
-    <div className="rounded-2xl bg-white/[0.04] backdrop-blur-3xl border border-white/10 overflow-hidden transition-all hover:border-white/20">
-      <button onClick={() => setExpanded(!expanded)} className="w-full text-left px-6 py-5 flex items-center gap-5 hover:bg-white/[0.02] transition-colors">
-        <div className="w-12 h-12 rounded-xl bg-white/[0.06] flex items-center justify-center text-2xl shrink-0">{icon}</div>
+    <div className="rounded-none bg-surface-container border border-outline-variant overflow-hidden transition-all hover:border-outline">
+      <button onClick={() => setExpanded(!expanded)} className="w-full text-left px-6 py-5 flex items-center gap-5 hover:bg-surface-high transition-colors">
+        <div className="w-12 h-12 rounded-none bg-surface-high flex items-center justify-center text-2xl shrink-0">{icon}</div>
         <div className="flex-1 min-w-0">
-          <div className="text-base font-black text-white mb-0.5">{name}</div>
-          {description && <div className="text-xs text-gray-400 leading-snug">{description}</div>}
+          <div className="text-base font-black text-on-surface mb-0.5">{name}</div>
+          {description && <div className="text-xs text-on-surface-variant leading-snug">{description}</div>}
         </div>
         <div className="flex items-center gap-4 shrink-0">
           <div className="text-right">
             <div className="font-mono text-sm font-black">
-              <span className="text-cyan-400">{proScore}</span>
-              <span className="text-gray-600 mx-1.5">vs</span>
-              <span className="text-fuchsia-400">{conScore}</span>
+              <span className="text-pro">{proScore}</span>
+              <span className="text-on-surface-variant mx-1.5">vs</span>
+              <span className="text-con">{conScore}</span>
             </div>
             {winner && (
-              <span className={`text-xs font-black uppercase px-2.5 py-0.5 rounded-full border inline-block mt-1 ${winnerBg} ${winnerColor}`}>
+              <span className={`text-xs font-black rounded-none border uppercase tracking-widest px-3 py-0.5 inline-block mt-1 ${winnerBg} ${winnerColor}`}>
                 {winner === "pro" ? "Pro wins" : winner === "con" ? "Con wins" : "Tie"}
               </span>
             )}
           </div>
-          <span className={`text-sm text-gray-500 transition-transform ${expanded ? "rotate-180" : ""}`}>▼</span>
+          <span className={`text-sm text-on-surface-variant transition-transform ${expanded ? "rotate-180" : ""}`}>▼</span>
         </div>
       </button>
       {expanded && (
-        <div className="px-6 pb-6 space-y-5 border-t border-white/[0.08]">
+        <div className="px-6 pb-6 space-y-5 border-t border-outline-variant">
           {winnerExpl && (
-            <div className="pt-5 p-4 rounded-xl bg-white/[0.03] border border-white/[0.06]">
-              <div className="text-xs font-black uppercase tracking-widest text-yellow-500/80 mb-2">Winner Explanation</div>
-              <p className="text-sm text-gray-200 leading-relaxed">{winnerExpl}</p>
+            <div className="pt-5 p-4 rounded-none bg-surface-low border border-outline-variant">
+              <div className="text-xs font-black uppercase tracking-widest text-on-surface-variant mb-2">Winner Explanation</div>
+              <p className="text-sm text-on-surface leading-relaxed">{winnerExpl}</p>
             </div>
           )}
 
           {/* Per-Criterion Breakdown */}
           {judge.criteria && judge.criteria.length > 0 && (
             <div className="pt-2">
-              <div className="text-xs font-black uppercase tracking-widest text-gray-500 mb-3">Scoring Breakdown</div>
+              <div className="text-xs font-black uppercase tracking-widest text-on-surface-variant mb-3">Scoring Breakdown</div>
               <div className="space-y-3">
                 {judge.criteria.map((c: CriterionScore, ci: number) => (
-                  <div key={ci} className="p-3 rounded-xl bg-white/[0.02] border border-white/[0.06]">
+                  <div key={ci} className="p-3 rounded-none bg-surface-low border border-outline-variant">
                     <div className="flex items-center justify-between mb-2">
-                      <span className="text-xs font-bold text-gray-300">{c.name}</span>
+                      <span className="text-xs font-bold text-on-surface">{c.name}</span>
                       <div className="flex items-center gap-3">
-                        <span className="text-[10px] text-gray-500 font-medium">{Math.round(c.weight * 100)}%</span>
+                        <span className="text-[10px] text-on-surface-variant font-medium">{Math.round(c.weight * 100)}%</span>
                         <span className="font-mono text-xs font-bold">
-                          <span className="text-cyan-400">{c.pro_score}</span>
-                          <span className="text-gray-600 mx-1">vs</span>
-                          <span className="text-fuchsia-400">{c.con_score}</span>
+                          <span className="text-pro">{c.pro_score}</span>
+                          <span className="text-on-surface-variant mx-1">vs</span>
+                          <span className="text-con">{c.con_score}</span>
                         </span>
                       </div>
                     </div>
                     <div className="grid md:grid-cols-2 gap-2">
-                      <div className="text-[11px] text-gray-400 leading-snug">
-                        <span className="text-cyan-500/70 font-bold">Pro:</span> {c.pro_justification}
+                      <div className="text-[11px] text-on-surface-variant leading-snug">
+                        <span className="text-pro/70 font-bold">Pro:</span> {c.pro_justification}
                       </div>
-                      <div className="text-[11px] text-gray-400 leading-snug">
-                        <span className="text-fuchsia-500/70 font-bold">Con:</span> {c.con_justification}
+                      <div className="text-[11px] text-on-surface-variant leading-snug">
+                        <span className="text-con/70 font-bold">Con:</span> {c.con_justification}
                       </div>
                     </div>
                   </div>
                 ))}
               </div>
-              <div className="mt-3 p-2 rounded-lg bg-white/[0.02] border border-white/[0.04] text-[10px] text-gray-500">
-                <span className="font-bold">Aggregate:</span> Weighted sum of criteria scores → Pro: <span className="text-cyan-400 font-mono">{proScore}</span> · Con: <span className="text-fuchsia-400 font-mono">{conScore}</span>
+              <div className="mt-3 p-2 rounded-none bg-surface-low border border-outline-variant text-[10px] text-on-surface-variant">
+                <span className="font-bold">Aggregate:</span> Weighted sum of criteria scores → Pro: <span className="text-pro font-mono">{proScore}</span> · Con: <span className="text-con font-mono">{conScore}</span>
               </div>
             </div>
           )}
 
           {(proStrongest || conStrongest) && (
             <div>
-              <div className="text-xs font-black uppercase tracking-widest text-gray-500 mb-3">Strongest Moves</div>
+              <div className="text-xs font-black uppercase tracking-widest text-on-surface-variant mb-3">Strongest Moves</div>
               <div className="grid md:grid-cols-2 gap-4">
                 {proStrongest && (
-                  <div className="p-4 rounded-xl bg-cyan-500/[0.06] border border-cyan-500/20">
+                  <div className="p-4 rounded-none bg-pro/[0.06] border-l-2 border-pro">
                     <div className="flex items-center gap-2 mb-2">
-                      <div className="w-6 h-6 rounded-lg bg-cyan-500/20 flex items-center justify-center text-xs font-black text-cyan-400">P</div>
-                      <span className="text-xs font-black uppercase tracking-widest text-cyan-400">Pro</span>
+                      <div className="w-6 h-6 rounded-none bg-pro/20 flex items-center justify-center text-xs font-black text-pro">P</div>
+                      <span className="text-xs font-black uppercase tracking-widest text-pro">Pro</span>
                     </div>
-                    <p className="text-sm text-gray-300 leading-relaxed">{proStrongest}</p>
+                    <p className="text-sm text-on-surface leading-relaxed">{proStrongest}</p>
                   </div>
                 )}
                 {conStrongest && (
-                  <div className="p-4 rounded-xl bg-fuchsia-500/[0.06] border border-fuchsia-500/20">
+                  <div className="p-4 rounded-none bg-con/[0.06] border-l-2 border-con">
                     <div className="flex items-center gap-2 mb-2">
-                      <div className="w-6 h-6 rounded-lg bg-fuchsia-500/20 flex items-center justify-center text-xs font-black text-fuchsia-400">C</div>
-                      <span className="text-xs font-black uppercase tracking-widest text-fuchsia-400">Con</span>
+                      <div className="w-6 h-6 rounded-none bg-con/20 flex items-center justify-center text-xs font-black text-con">C</div>
+                      <span className="text-xs font-black uppercase tracking-widest text-con">Con</span>
                     </div>
-                    <p className="text-sm text-gray-300 leading-relaxed">{conStrongest}</p>
+                    <p className="text-sm text-on-surface leading-relaxed">{conStrongest}</p>
                   </div>
                 )}
               </div>
@@ -157,24 +157,24 @@ function JudgeCard({ judge }: { judge: JudgeResult }) {
 
           {(proWeakest || conWeakest) && (
             <div>
-              <div className="text-xs font-black uppercase tracking-widest text-gray-500 mb-3">Weakest Moves</div>
+              <div className="text-xs font-black uppercase tracking-widest text-on-surface-variant mb-3">Weakest Moves</div>
               <div className="grid md:grid-cols-2 gap-4">
                 {proWeakest && (
-                  <div className="p-4 rounded-xl bg-white/[0.02] border border-white/[0.08]">
+                  <div className="p-4 rounded-none bg-surface-low border border-outline-variant">
                     <div className="flex items-center gap-2 mb-2">
-                      <div className="w-6 h-6 rounded-lg bg-cyan-500/10 flex items-center justify-center text-xs font-black text-cyan-500/60">P</div>
-                      <span className="text-xs font-bold uppercase tracking-widest text-gray-500">Pro</span>
+                      <div className="w-6 h-6 rounded-none bg-pro/10 flex items-center justify-center text-xs font-black text-pro/60">P</div>
+                      <span className="text-xs font-bold uppercase tracking-widest text-on-surface-variant">Pro</span>
                     </div>
-                    <p className="text-sm text-gray-400 leading-relaxed">{proWeakest}</p>
+                    <p className="text-sm text-on-surface-variant leading-relaxed">{proWeakest}</p>
                   </div>
                 )}
                 {conWeakest && (
-                  <div className="p-4 rounded-xl bg-white/[0.02] border border-white/[0.08]">
+                  <div className="p-4 rounded-none bg-surface-low border border-outline-variant">
                     <div className="flex items-center gap-2 mb-2">
-                      <div className="w-6 h-6 rounded-lg bg-fuchsia-500/10 flex items-center justify-center text-xs font-black text-fuchsia-500/60">C</div>
-                      <span className="text-xs font-bold uppercase tracking-widest text-gray-500">Con</span>
+                      <div className="w-6 h-6 rounded-none bg-con/10 flex items-center justify-center text-xs font-black text-con/60">C</div>
+                      <span className="text-xs font-bold uppercase tracking-widest text-on-surface-variant">Con</span>
                     </div>
-                    <p className="text-sm text-gray-400 leading-relaxed">{conWeakest}</p>
+                    <p className="text-sm text-on-surface-variant leading-relaxed">{conWeakest}</p>
                   </div>
                 )}
               </div>
@@ -182,9 +182,9 @@ function JudgeCard({ judge }: { judge: JudgeResult }) {
           )}
 
           {reasoning && (
-            <div className="p-4 rounded-xl bg-white/[0.02] border border-white/[0.06]">
-              <div className="text-xs font-black uppercase tracking-widest text-gray-500 mb-2">Full Reasoning</div>
-              <p className="text-sm text-gray-300 leading-relaxed whitespace-pre-line">{reasoning}</p>
+            <div className="p-4 rounded-none bg-surface-low border border-outline-variant">
+              <div className="text-xs font-black uppercase tracking-widest text-on-surface-variant mb-2">Full Reasoning</div>
+              <p className="text-sm text-on-surface leading-relaxed whitespace-pre-line">{reasoning}</p>
             </div>
           )}
         </div>
@@ -1060,31 +1060,27 @@ export default function DebatePage() {
   const judges = judgingResults?.judges || [];
 
   return (
-    <div className="min-h-screen bg-slate-950 text-gray-100 flex flex-col relative overflow-hidden">
-      {/* Background Meshes */}
-      <div className="absolute top-[-20%] left-[-10%] w-[50%] h-[50%] bg-fuchsia-600/20 rounded-full blur-[120px] mix-blend-screen animate-pulse pointer-events-none" style={{ animationDuration: "8s" }} />
-      <div className="absolute top-[20%] right-[-10%] w-[60%] h-[60%] bg-blue-600/20 rounded-full blur-[150px] mix-blend-screen animate-pulse pointer-events-none" style={{ animationDuration: "10s" }} />
-      <div className="absolute bottom-[-20%] left-[20%] w-[50%] h-[50%] bg-violet-600/20 rounded-full blur-[100px] mix-blend-screen animate-pulse pointer-events-none" style={{ animationDuration: "12s" }} />
+    <div className="min-h-screen bg-surface text-on-surface flex flex-col relative overflow-hidden">
 
       {/* ─── Header ─── */}
-      <header className="relative z-30 border-b border-white/[0.06]">
+      <header className="relative z-30 border-b border-outline-variant bg-surface-low">
         {/* Top bar */}
-        <div className="px-6 py-3 flex items-center justify-between bg-gradient-to-r from-cyan-950/30 via-slate-900/60 to-fuchsia-950/30 backdrop-blur-3xl">
+        <div className="px-6 py-3 flex items-center justify-between">
           <a href="/" className="hover:opacity-80 transition-opacity">
-            <span className="text-lg font-black tracking-tighter bg-gradient-to-r from-cyan-400 via-blue-500 to-purple-500 bg-clip-text text-transparent">DebateMeBro</span>
+            <span className="text-lg font-headline font-black tracking-tighter text-on-surface">DebateMeBro</span>
           </a>
           <div className="flex items-center gap-3">
             {isDemoMode
-              ? <span className="text-[10px] font-bold text-amber-400 uppercase tracking-widest bg-amber-900/30 px-2.5 py-1 rounded-full border border-amber-500/30">Demo</span>
-              : <span className="text-[10px] font-bold text-sky-400 uppercase tracking-widest bg-sky-900/30 px-2.5 py-1 rounded-full border border-sky-500/30">Live</span>
+              ? <span className="text-[10px] font-bold text-amber-400 uppercase tracking-widest bg-amber-900/30 px-2.5 py-1 rounded-none border border-amber-500/30">Demo</span>
+              : <span className="text-[10px] font-bold text-sky-400 uppercase tracking-widest bg-sky-900/30 px-2.5 py-1 rounded-none border border-sky-500/30">Live</span>
             }
-            {isFromCache && <span className="text-[10px] font-bold text-violet-400 uppercase tracking-widest bg-violet-900/30 px-2.5 py-1 rounded-full border border-violet-500/30">Cached</span>}
+            {isFromCache && <span className="text-[10px] font-bold text-violet-400 uppercase tracking-widest bg-violet-900/30 px-2.5 py-1 rounded-none border border-violet-500/30">Cached</span>}
             {isStreaming ? (
-              <span className="flex items-center gap-2 text-[10px] font-bold text-emerald-400 uppercase tracking-widest bg-emerald-900/30 px-2.5 py-1 rounded-full border border-emerald-500/30 shadow-[0_0_10px_rgba(52,211,153,0.2)]">
-                <span className="w-1.5 h-1.5 bg-emerald-400 rounded-full animate-pulse shadow-[0_0_6px_rgba(52,211,153,0.8)]" /> Live
+              <span className="flex items-center gap-2 text-[10px] font-bold text-emerald-400 uppercase tracking-widest bg-emerald-900/30 px-2.5 py-1 rounded-none border border-emerald-500/30 shadow-[0_0_10px_rgba(52,211,153,0.2)]">
+                <span className="w-1.5 h-1.5 bg-emerald-400 rounded-none animate-pulse shadow-[0_0_6px_rgba(52,211,153,0.8)]" /> Live
               </span>
             ) : (
-              <span className="text-[10px] font-bold text-gray-500 uppercase tracking-widest bg-white/5 px-2.5 py-1 rounded-full border border-white/10">
+              <span className="text-[10px] font-bold text-on-surface-variant uppercase tracking-widest bg-surface-container px-2.5 py-1 rounded-none border border-outline-variant">
                 {completedPhases.includes("judging") ? "Complete" : "Paused"}
               </span>
             )}
@@ -1092,15 +1088,15 @@ export default function DebatePage() {
         </div>
 
         {/* Topic title */}
-        <div className="px-6 py-4 text-center bg-black/30 backdrop-blur-xl">
-          <h1 className="text-lg lg:text-xl font-black text-white tracking-tight">
+        <div className="px-6 py-4 text-center bg-surface-container border-t border-outline-variant">
+          <h1 className="text-lg lg:text-xl font-headline font-black text-on-surface tracking-tight">
             {topicMeta?.resolution || (isDemoMode ? "Should the US adopt universal healthcare?" : `Debate: ${id}`)}
           </h1>
         </div>
 
         {/* ─── Persona Cards ─── */}
         {proPersona && conPersona && (
-          <div className="flex items-start gap-3 px-6 py-4 bg-gradient-to-r from-cyan-950/20 via-transparent to-fuchsia-950/20">
+          <div className="flex items-start gap-3 px-6 py-4 bg-surface-low border-t border-outline-variant">
             <div className="flex-1 min-w-0">
               <PersonaCard persona={proPersona} side="pro" position={topicMeta?.proPosition || (isDemoMode ? MOCK_POSITIONS.pro : "")} />
             </div>
@@ -1204,17 +1200,17 @@ export default function DebatePage() {
         <div className="px-6 py-4 bg-red-950/50 border-b border-red-500/30 backdrop-blur-xl relative z-10 flex flex-col sm:flex-row items-center justify-center gap-4">
           <span className="text-sm font-bold text-red-300">⚠️ {connectionError}</span>
           <div className="flex gap-3">
-            <button onClick={connectSSE} className="px-4 py-1.5 text-xs font-black uppercase tracking-widest bg-red-600/40 hover:bg-red-600/60 text-red-200 rounded-full border border-red-500/40 transition-all">Retry</button>
-            <button onClick={startDemoMode} className="px-4 py-1.5 text-xs font-black uppercase tracking-widest bg-amber-600/40 hover:bg-amber-600/60 text-amber-200 rounded-full border border-amber-500/40 transition-all">Run Demo</button>
+            <button onClick={connectSSE} className="px-4 py-1.5 text-xs font-black uppercase tracking-widest bg-red-600/40 hover:bg-red-600/60 text-red-200 rounded-none border border-red-500/40 transition-all">Retry</button>
+            <button onClick={startDemoMode} className="px-4 py-1.5 text-xs font-black uppercase tracking-widest bg-amber-600/40 hover:bg-amber-600/60 text-amber-200 rounded-none border border-amber-500/40 transition-all">Run Demo</button>
           </div>
         </div>
       )}
 
       {/* ─── Phase Transition ─── */}
       {phaseTransitionMsg && (
-        <div className="px-6 py-3 bg-purple-900/40 border-b border-purple-500/30 text-center backdrop-blur-xl relative z-10 shadow-[0_4px_20px_rgba(168,85,247,0.15)] flex justify-center items-center gap-3">
-          <div className="w-4 h-4 rounded-full border-2 border-purple-400 border-t-transparent animate-spin" />
-          <span className="text-sm font-bold text-purple-300 tracking-wider uppercase">{phaseTransitionMsg}</span>
+        <div className="px-6 py-3 bg-surface-container border-b border-outline-variant text-center relative z-10 flex justify-center items-center gap-3">
+          <div className="w-4 h-4 rounded-none border-2 border-pro border-t-transparent animate-spin" />
+          <span className="text-sm font-bold text-on-surface-variant tracking-wider uppercase">{phaseTransitionMsg}</span>
         </div>
       )}
 
@@ -1222,7 +1218,7 @@ export default function DebatePage() {
       {waitingForUser && (
         <div className="fixed bottom-8 left-1/2 -translate-x-1/2 z-50 animate-bounce">
           <button onClick={handleContinue}
-            className="px-8 py-4 text-sm font-black uppercase tracking-widest bg-gradient-to-r from-purple-600 to-blue-600 hover:from-purple-500 hover:to-blue-500 text-white rounded-2xl border border-white/20 shadow-[0_0_40px_rgba(168,85,247,0.4)] transition-all hover:scale-105 hover:shadow-[0_0_60px_rgba(168,85,247,0.6)]"
+            className="px-8 py-4 text-sm font-black uppercase tracking-widest bg-surface-high hover:bg-surface-bright text-on-surface rounded-none border border-outline-variant transition-all"
           >Continue →</button>
         </div>
       )}
@@ -1232,19 +1228,19 @@ export default function DebatePage() {
 
         {/* ══ Research Phase ══ */}
         {activePhase === "research" && (
-          <div className="flex-1 overflow-y-auto p-6 lg:p-10 bg-black/20">
+          <div className="flex-1 overflow-y-auto p-6 lg:p-10 bg-surface">
             <div className="max-w-6xl mx-auto">
               {/* Loading steps */}
               {!researchReady && (
                 <div className="text-center mb-8">
                   <div className="text-5xl mb-4">🔍</div>
-                  <h2 className="text-2xl font-black text-white mb-2">Research Phase</h2>
-                  <p className="text-gray-400 font-medium mb-6">Both AI Agents receive the complete research — Pro and Con — to build strategy from shared facts.</p>
+                  <h2 className="text-2xl font-headline font-black text-on-surface mb-2">Research Phase</h2>
+                  <p className="text-on-surface-variant font-medium mb-6">Both AI Agents receive the complete research — Pro and Con — to build strategy from shared facts.</p>
                   <div className="max-w-md mx-auto space-y-3 text-left">
                     {MOCK_RESEARCH_STEPS.slice(0, researchStepIdx).map((step, i) => (
-                      <div key={i} className="flex items-center gap-3 text-sm p-3 rounded-xl bg-white/5 border border-white/10">
+                      <div key={i} className="flex items-center gap-3 text-sm p-3 rounded-none bg-surface-container border border-outline-variant">
                         <span className="text-purple-400">🔍</span>
-                        <span className="text-gray-300 flex-1">{step.query}</span>
+                        <span className="text-on-surface flex-1">{step.query}</span>
                         <span className="text-emerald-400 font-mono font-bold text-xs">{step.results}</span>
                       </div>
                     ))}
@@ -1269,35 +1265,35 @@ export default function DebatePage() {
                 return (
                   <>
                     <div className="text-center mb-8">
-                      <h2 className="text-2xl font-black text-white mb-2">📚 Evidence Bundle</h2>
-                      <p className="text-sm text-gray-400 font-medium">
+                      <h2 className="text-2xl font-headline font-black text-on-surface mb-2">📚 Evidence Bundle</h2>
+                      <p className="text-sm text-on-surface-variant font-medium">
                         Both agents received the same research. {citationCount ? `${citationCount} sources indexed.` : "Expand any section to explore the evidence."}
                       </p>
                     </div>
                     <div className="grid lg:grid-cols-2 gap-8">
                       <div>
                         <div className="flex items-center gap-3 mb-4">
-                          <div className="w-8 h-8 rounded-xl bg-gradient-to-br from-cyan-400 to-blue-600 flex items-center justify-center text-sm font-black text-white">P</div>
+                          <div className="w-8 h-8 rounded-none bg-pro/20 flex items-center justify-center text-sm font-black text-pro">P</div>
                           <div>
-                            <div className="text-xs font-black uppercase tracking-widest text-cyan-400">Pro Research</div>
-                            <div className="text-xs text-gray-500">{proResearch.length} argument dimensions • {proResearch.reduce((a, s) => a + s.sources.length, 0)} sources</div>
+                            <div className="text-xs font-black uppercase tracking-widest text-pro">Pro Research</div>
+                            <div className="text-xs text-on-surface-variant">{proResearch.length} argument dimensions • {proResearch.reduce((a, s) => a + s.sources.length, 0)} sources</div>
                           </div>
                         </div>
                         <ResearchCard side="pro" sections={proResearch} />
-                        <button onClick={() => setDocModal("pro")} className="mt-3 w-full py-3 rounded-xl text-xs font-black uppercase tracking-widest text-cyan-400 bg-cyan-500/10 hover:bg-cyan-500/20 border border-cyan-500/20 transition-all">
+                        <button onClick={() => setDocModal("pro")} className="mt-3 w-full py-3 rounded-none text-xs font-black uppercase tracking-widest text-pro bg-pro/10 hover:bg-pro/20 border border-pro/20 transition-all">
                           📄 View Full Pro Document
                         </button>
                       </div>
                       <div>
                         <div className="flex items-center gap-3 mb-4">
-                          <div className="w-8 h-8 rounded-xl bg-gradient-to-br from-fuchsia-400 to-purple-600 flex items-center justify-center text-sm font-black text-white">C</div>
+                          <div className="w-8 h-8 rounded-none bg-con/20 flex items-center justify-center text-sm font-black text-con">C</div>
                           <div>
-                            <div className="text-xs font-black uppercase tracking-widest text-fuchsia-400">Con Research</div>
-                            <div className="text-xs text-gray-500">{conResearch.length} argument dimensions • {conResearch.reduce((a, s) => a + s.sources.length, 0)} sources</div>
+                            <div className="text-xs font-black uppercase tracking-widest text-con">Con Research</div>
+                            <div className="text-xs text-on-surface-variant">{conResearch.length} argument dimensions • {conResearch.reduce((a, s) => a + s.sources.length, 0)} sources</div>
                           </div>
                         </div>
                         <ResearchCard side="con" sections={conResearch} />
-                        <button onClick={() => setDocModal("con")} className="mt-3 w-full py-3 rounded-xl text-xs font-black uppercase tracking-widest text-fuchsia-400 bg-fuchsia-500/10 hover:bg-fuchsia-500/20 border border-fuchsia-500/20 transition-all">
+                        <button onClick={() => setDocModal("con")} className="mt-3 w-full py-3 rounded-none text-xs font-black uppercase tracking-widest text-con bg-con/10 hover:bg-con/20 border border-con/20 transition-all">
                           📄 View Full Con Document
                         </button>
                       </div>
@@ -1307,19 +1303,19 @@ export default function DebatePage() {
                     {(internalAnalysis["research_consultation"]?.pro || internalAnalysis["research_consultation"]?.con) && (
                       <div className="mt-10">
                         <div className="text-center mb-6">
-                          <h3 className="text-lg font-black text-white mb-1">🧠 Agent Strategic Analysis</h3>
-                          <p className="text-xs text-gray-400 font-medium">Each agent privately analyzed ALL research to plan their strategy.</p>
+                          <h3 className="text-lg font-headline font-black text-on-surface mb-1">🧠 Agent Strategic Analysis</h3>
+                          <p className="text-xs text-on-surface-variant font-medium">Each agent privately analyzed ALL research to plan their strategy.</p>
                         </div>
                         <div className="grid md:grid-cols-2 gap-6">
                           <div>
                             <div className="flex items-center gap-3 mb-3 ml-2">
-                              <span className="text-cyan-400 font-black uppercase text-xs tracking-widest bg-cyan-900/40 px-3 py-1 rounded-full border border-cyan-500/30">{proPersona?.name || "Pro"} — Strategy</span>
+                              <span className="text-pro font-black uppercase text-xs tracking-widest bg-pro/10 px-3 py-1 rounded-none border border-pro/30">{proPersona?.name || "Pro"} — Strategy</span>
                             </div>
                             <StrategicAnalysisPanel content={internalAnalysis["research_consultation"]?.pro || ""} side="pro" />
                           </div>
                           <div>
                             <div className="flex items-center gap-3 mb-3 ml-2">
-                              <span className="text-fuchsia-400 font-black uppercase text-xs tracking-widest bg-fuchsia-900/40 px-3 py-1 rounded-full border border-fuchsia-500/30">{conPersona?.name || "Con"} — Strategy</span>
+                              <span className="text-con font-black uppercase text-xs tracking-widest bg-con/10 px-3 py-1 rounded-none border border-con/30">{conPersona?.name || "Con"} — Strategy</span>
                             </div>
                             <StrategicAnalysisPanel content={internalAnalysis["research_consultation"]?.con || ""} side="con" />
                           </div>
@@ -1336,20 +1332,20 @@ export default function DebatePage() {
 
         {/* ══ Judging ══ */}
         {activePhase === "judging" && (
-          <div className="flex-1 overflow-y-auto p-8 lg:p-12 bg-black/20">
+          <div className="flex-1 overflow-y-auto p-8 lg:p-12 bg-surface">
             <div className="max-w-5xl mx-auto">
 
               {/* Deliberating state — shown while judges haven't returned */}
               {!judgingReady && (
                 <div className="flex flex-col items-center justify-center py-24 animate-[fadeIn_0.5s_ease-out]">
                   <div className="text-6xl mb-6">⚖️</div>
-                  <h2 className="text-2xl font-black text-white mb-3">Judges Are Deliberating</h2>
-                  <p className="text-sm text-gray-400 font-medium mb-8 max-w-md text-center">
+                  <h2 className="text-2xl font-headline font-black text-on-surface mb-3">Judges Are Deliberating</h2>
+                  <p className="text-sm text-on-surface-variant font-medium mb-8 max-w-md text-center">
                     Three AI judges — Logic, Evidence, and Engagement — are independently evaluating the full debate transcript.
                   </p>
                   <div className="flex items-center gap-4">
-                    <div className="w-10 h-10 rounded-full border-2 border-purple-400 border-t-transparent animate-spin" />
-                    <span className="text-xs font-black uppercase tracking-widest text-purple-400 animate-pulse">Scoring in progress...</span>
+                    <div className="w-10 h-10 rounded-none border-2 border-pro border-t-transparent animate-spin" />
+                    <span className="text-xs font-black uppercase tracking-widest text-on-surface-variant animate-pulse">Scoring in progress...</span>
                   </div>
                 </div>
               )}
@@ -1360,29 +1356,29 @@ export default function DebatePage() {
                   {/* Winner Banner */}
                   <div className="text-center mb-8">
                     <div className="text-5xl mb-4">📊</div>
-                    <h2 className="text-2xl font-black text-white mb-2">Judging Results</h2>
-                    <div className={`inline-block px-6 py-2 rounded-full text-sm font-black uppercase tracking-widest mt-2 ${rawWinner === "pro" ? "bg-cyan-600/30 text-cyan-300 border border-cyan-500/30" : rawWinner === "con" ? "bg-fuchsia-600/30 text-fuchsia-300 border border-fuchsia-500/30" : "bg-gray-600/30 text-gray-300 border border-gray-500/30"}`}>
+                    <h2 className="text-2xl font-headline font-black text-on-surface mb-2">Judging Results</h2>
+                    <div className={`inline-block px-6 py-2 rounded-none text-sm font-black uppercase tracking-widest mt-2 ${rawWinner === "pro" ? "bg-pro/20 text-pro border border-pro/30" : rawWinner === "con" ? "bg-con/20 text-con border border-con/30" : "bg-surface-high text-on-surface-variant border border-outline-variant"}`}>
                       {debateWinner} wins — {proTotal.toFixed(2)} vs {conTotal.toFixed(2)}
                     </div>
                   </div>
 
                   {/* Score Overview */}
-                  <div className="p-8 rounded-[2rem] bg-white/[0.03] backdrop-blur-3xl border border-white/10 shadow-lg mb-8">
-                    <div className="flex justify-between text-xs text-gray-500 mb-6">
-                      <span className="text-cyan-400 font-black uppercase tracking-widest">← Pro ({proPersona?.name})</span>
-                      <span className="text-fuchsia-400 font-black uppercase tracking-widest">Con ({conPersona?.name}) →</span>
+                  <div className="p-8 rounded-none bg-surface-container border border-outline-variant shadow-lg mb-8">
+                    <div className="flex justify-between text-xs text-on-surface-variant mb-6">
+                      <span className="text-pro font-black uppercase tracking-widest">← Pro ({proPersona?.name})</span>
+                      <span className="text-con font-black uppercase tracking-widest">Con ({conPersona?.name}) →</span>
                     </div>
                     <ScoreBar label="Logical Validity" weight="30%" proScore={proScores.logic ?? 0} conScore={conScores.logic ?? 0} />
                     <ScoreBar label="Evidence Quality" weight="25%" proScore={proScores.evidence ?? 0} conScore={conScores.evidence ?? 0} />
                     <ScoreBar label="Refutation Strength" weight="25%" proScore={proScores.refutation ?? 0} conScore={conScores.refutation ?? 0} />
                     <ScoreBar label="Steelmanning Quality" weight="20%" proScore={proScores.steelman ?? 0} conScore={conScores.steelman ?? 0} />
-                    <div className="mt-6 pt-6 border-t border-white/10">
+                    <div className="mt-6 pt-6 border-t border-outline-variant">
                       <div className="flex justify-between items-center text-sm">
-                        <span className="text-gray-400 font-bold uppercase tracking-widest text-xs">Weighted Total</span>
+                        <span className="text-on-surface-variant font-bold uppercase tracking-widest text-xs">Weighted Total</span>
                         <span className="font-mono font-black text-lg">
-                          <span className="text-cyan-400">{proTotal.toFixed(2)}</span>
-                          <span className="text-gray-600 mx-2">vs</span>
-                          <span className="text-fuchsia-400">{conTotal.toFixed(2)}</span>
+                          <span className="text-pro">{proTotal.toFixed(2)}</span>
+                          <span className="text-on-surface-variant mx-2">vs</span>
+                          <span className="text-con">{conTotal.toFixed(2)}</span>
                         </span>
                       </div>
                     </div>
@@ -1390,16 +1386,16 @@ export default function DebatePage() {
 
                   {/* Verdict Summary */}
                   {judgeVerdict && (
-                    <div className="p-6 rounded-[2rem] bg-white/[0.03] backdrop-blur-3xl border border-white/10 shadow-lg mb-8">
-                      <div className="text-xs text-gray-500 mb-3 uppercase tracking-widest font-black">AI Judges Verdict</div>
-                      <p className="text-sm text-gray-300 leading-relaxed"><strong className="text-yellow-400">{debateWinner} wins.</strong> {judgeVerdict.summary}</p>
+                    <div className="p-6 rounded-none bg-surface-container border border-outline-variant shadow-lg mb-8">
+                      <div className="text-xs text-on-surface-variant mb-3 uppercase tracking-widest font-black">AI Judges Verdict</div>
+                      <p className="text-sm text-on-surface leading-relaxed"><strong className="text-on-surface">{debateWinner} wins.</strong> {judgeVerdict.summary}</p>
                     </div>
                   )}
 
                   {/* Per-Judge Breakdown */}
                   {judges.length > 0 && (
                     <div className="mb-8">
-                      <h3 className="text-lg font-black text-white mb-4">Individual Judge Analysis</h3>
+                      <h3 className="text-lg font-headline font-black text-on-surface mb-4">Individual Judge Analysis</h3>
                       <div className="space-y-4">
                         {judges.map((judge, idx: number) => (
                           <JudgeCard key={idx} judge={judge} />
@@ -1409,15 +1405,15 @@ export default function DebatePage() {
                   )}
 
                   {/* Your Vote */}
-                  <div className="p-6 rounded-[2rem] bg-white/[0.03] backdrop-blur-3xl border border-white/10 shadow-lg">
-                    <div className="text-xs text-gray-500 mb-4 uppercase tracking-widest font-black">Your Vote</div>
+                  <div className="p-6 rounded-none bg-surface-container border border-outline-variant shadow-lg">
+                    <div className="text-xs text-on-surface-variant mb-4 uppercase tracking-widest font-black">Your Vote</div>
                     <div className="flex gap-3 mb-4">
-                      <button onClick={() => handleVote("pro")} disabled={isVoting || !!userVote} className={`flex-1 py-3 rounded-xl text-sm font-black transition-all ${userVote === "pro" ? "bg-cyan-600 text-white ring-2 ring-cyan-400/40 shadow-[0_0_20px_rgba(6,182,212,0.3)]" : "bg-white/5 text-gray-400 hover:bg-white/10 border border-white/10"} ${(isVoting || !!userVote) ? "opacity-60 cursor-not-allowed" : ""}`}>👍 Pro Wins</button>
-                      <button onClick={() => handleVote("con")} disabled={isVoting || !!userVote} className={`flex-1 py-3 rounded-xl text-sm font-black transition-all ${userVote === "con" ? "bg-fuchsia-600 text-white ring-2 ring-fuchsia-400/40 shadow-[0_0_20px_rgba(217,70,239,0.3)]" : "bg-white/5 text-gray-400 hover:bg-white/10 border border-white/10"} ${(isVoting || !!userVote) ? "opacity-60 cursor-not-allowed" : ""}`}>👍 Con Wins</button>
+                      <button onClick={() => handleVote("pro")} disabled={isVoting || !!userVote} className={`flex-1 py-3 rounded-none text-sm font-black uppercase tracking-widest transition-all border border-outline-variant ${userVote === "pro" ? "bg-pro/20 border-pro text-pro" : "bg-surface-high text-on-surface-variant hover:bg-surface-bright"} ${(isVoting || !!userVote) ? "opacity-60 cursor-not-allowed" : ""}`}>👍 Pro Wins</button>
+                      <button onClick={() => handleVote("con")} disabled={isVoting || !!userVote} className={`flex-1 py-3 rounded-none text-sm font-black uppercase tracking-widest transition-all border border-outline-variant ${userVote === "con" ? "bg-con/20 border-con text-con" : "bg-surface-high text-on-surface-variant hover:bg-surface-bright"} ${(isVoting || !!userVote) ? "opacity-60 cursor-not-allowed" : ""}`}>👍 Con Wins</button>
                     </div>
                     {userVote && (
-                      <div className="text-xs text-gray-400 p-4 bg-white/5 rounded-xl border border-white/10">
-                        <div className="font-black text-emerald-400 mb-1">Vote recorded! Thank you for your feedback.</div>
+                      <div className="text-xs text-on-surface-variant p-4 bg-surface-high rounded-none border border-outline-variant">
+                        <div className="font-black text-on-surface mb-1">Vote recorded! Thank you for your feedback.</div>
                         {voteTally && <span>Community: {voteTally.pro_votes} Pro · {voteTally.con_votes} Con ({voteTally.total_votes} total)</span>}
                       </div>
                     )}
@@ -1430,23 +1426,23 @@ export default function DebatePage() {
 
         {/* ══ Internal Eval ══ */}
         {["eval_openings", "eval_full_debate"].includes(activePhase) && (
-          <div className="flex-1 overflow-y-auto p-12 bg-black/20">
+          <div className="flex-1 overflow-y-auto p-12 bg-surface">
             <div className="max-w-6xl mx-auto">
               <div className="text-center mb-10">
-                <h3 className="text-2xl font-black text-white mb-2">🧠 {activePhase === "eval_openings" ? "Evaluating Opening Arguments" : "Evaluating Full Debate"}</h3>
-                <p className="text-sm text-gray-400 font-medium">Both agents are privately analyzing the preceding arguments to plan their next moves.</p>
-                {isStreaming && <div className="mt-4 flex justify-center"><div className="w-8 h-8 rounded-full border-2 border-purple-400 border-t-transparent animate-spin" /></div>}
+                <h3 className="text-2xl font-headline font-black text-on-surface mb-2">🧠 {activePhase === "eval_openings" ? "Evaluating Opening Arguments" : "Evaluating Full Debate"}</h3>
+                <p className="text-sm text-on-surface-variant font-medium">Both agents are privately analyzing the preceding arguments to plan their next moves.</p>
+                {isStreaming && <div className="mt-4 flex justify-center"><div className="w-8 h-8 rounded-none border-2 border-pro border-t-transparent animate-spin" /></div>}
               </div>
               <div className="grid md:grid-cols-2 gap-8">
                 <div>
                   <div className="flex items-center gap-3 mb-3 ml-2">
-                    <span className="text-cyan-400 font-black uppercase text-xs tracking-widest bg-cyan-900/40 px-3 py-1 rounded-full border border-cyan-500/30">{proPersona?.name || "Pro"} — Analysis</span>
+                    <span className="text-pro font-black uppercase text-xs tracking-widest bg-pro/10 px-3 py-1 rounded-none border border-pro/30">{proPersona?.name || "Pro"} — Analysis</span>
                   </div>
                   <StrategicAnalysisPanel content={internalAnalysis[activePhase]?.pro || ""} side="pro" />
                 </div>
                 <div>
                   <div className="flex items-center gap-3 mb-3 ml-2">
-                    <span className="text-fuchsia-400 font-black uppercase text-xs tracking-widest bg-fuchsia-900/40 px-3 py-1 rounded-full border border-fuchsia-500/30">{conPersona?.name || "Con"} — Analysis</span>
+                    <span className="text-con font-black uppercase text-xs tracking-widest bg-con/10 px-3 py-1 rounded-none border border-con/30">{conPersona?.name || "Con"} — Analysis</span>
                   </div>
                   <StrategicAnalysisPanel content={internalAnalysis[activePhase]?.con || ""} side="con" />
                 </div>
@@ -1458,23 +1454,23 @@ export default function DebatePage() {
         {/* ══ Argument Phases ══ */}
         {["opening", "rebuttal", "closing"].includes(activePhase) && (
           <>
-            <div className="flex-1 border-r border-cyan-900/30 overflow-y-auto p-8 lg:p-12 relative bg-gradient-to-b from-cyan-950/20 to-transparent">
+            <div className="flex-1 border-r border-outline-variant overflow-y-auto p-8 lg:p-12 relative bg-surface-low">
               {proSideTurns.map((turn, i) => (
                 <ArgumentCard key={i} turn={turn} persona={proPersona} isStreaming={isStreaming && i === proSideTurns.length - 1} />
               ))}
               {proSideTurns.length === 0 && (
-                <div className="flex flex-col items-center justify-center h-full text-cyan-500/40">
+                <div className="flex flex-col items-center justify-center h-full text-pro/40">
                   <span className="text-4xl mb-4 opacity-50">⏳</span>
                   <p className="text-xs font-black uppercase tracking-widest opacity-70">Awaiting Pro...</p>
                 </div>
               )}
             </div>
-            <div className="flex-1 overflow-y-auto p-8 lg:p-12 relative bg-gradient-to-b from-fuchsia-950/20 to-transparent">
+            <div className="flex-1 overflow-y-auto p-8 lg:p-12 relative bg-surface">
               {conSideTurns.map((turn, i) => (
                 <ArgumentCard key={i} turn={turn} persona={conPersona} isStreaming={isStreaming && i === conSideTurns.length - 1} />
               ))}
               {conSideTurns.length === 0 && (
-                <div className="flex flex-col items-center justify-center h-full text-fuchsia-500/40">
+                <div className="flex flex-col items-center justify-center h-full text-con/40">
                   <span className="text-4xl mb-4 opacity-50">⏳</span>
                   <p className="text-xs font-black uppercase tracking-widest opacity-70">Awaiting Con...</p>
                 </div>

--- a/frontend/src/app/debates/new/page.tsx
+++ b/frontend/src/app/debates/new/page.tsx
@@ -146,24 +146,19 @@ function NewDebatePageInner() {
   };
 
   return (
-    <div className="min-h-screen bg-slate-950 text-gray-100 font-sans relative overflow-hidden">
-      {/* Background */}
-      <div className="absolute inset-0 pointer-events-none overflow-hidden z-0">
-        <div className="absolute -top-[20%] -left-[10%] w-[50vw] h-[50vw] bg-purple-600/10 blur-[120px] rounded-full mix-blend-screen" />
-        <div className="absolute top-[40%] -right-[15%] w-[60vw] h-[60vw] bg-blue-600/10 blur-[120px] rounded-full mix-blend-screen" />
-      </div>
+    <div className="min-h-screen bg-surface text-on-surface font-sans relative overflow-hidden">
 
       {/* Header */}
-      <header className="relative z-10 border-b border-white/10 bg-black/40 backdrop-blur-3xl px-8 py-5 flex items-center justify-between">
+      <header className="relative z-10 border-b border-outline-variant bg-black/40 backdrop-blur-3xl px-8 py-5 flex items-center justify-between">
         <Link href="/" className="flex items-center gap-3 group">
-          <div className="w-8 h-8 rounded-xl bg-gradient-to-br from-cyan-400 via-blue-500 to-purple-600 flex items-center justify-center shadow-[0_0_20px_rgba(56,189,248,0.5)]">
-            <span className="text-white font-bold text-sm">🎯</span>
+          <div className="w-8 h-8 rounded-none bg-pro flex items-center justify-center">
+            <span className="text-[#00195b] font-bold text-sm">🎯</span>
           </div>
-          <span className="text-xl font-black tracking-tighter bg-clip-text text-transparent bg-gradient-to-r from-white to-gray-400">
+          <span className="text-xl font-black tracking-tighter text-on-surface">
             DebateMeBro
           </span>
         </Link>
-        <div className="text-sm text-gray-500">Custom Topic</div>
+        <div className="text-sm text-on-surface-variant">Custom Topic</div>
       </header>
 
       {/* Main */}
@@ -177,20 +172,20 @@ function NewDebatePageInner() {
           ].map((s, i) => (
             <div key={s.id} className="flex items-center gap-3">
               <div
-                className={`w-10 h-10 rounded-full flex items-center justify-center text-sm font-black transition-all ${
+                className={`w-10 h-10 rounded-none flex items-center justify-center text-sm font-black transition-all ${
                   step === s.id
-                    ? "bg-gradient-to-br from-cyan-500 to-blue-600 text-white shadow-[0_0_20px_rgba(6,182,212,0.4)]"
+                    ? "bg-pro text-[#00195b]"
                     : (["input", "research", "upload"].indexOf(step) > i)
-                    ? "bg-emerald-500/20 text-emerald-400 border border-emerald-500/30"
-                    : "bg-white/5 text-gray-600 border border-white/10"
+                    ? "bg-surface-bright text-on-surface border border-outline-variant"
+                    : "bg-surface-high text-on-surface-variant border border-outline-variant"
                 }`}
               >
                 {["input", "research", "upload"].indexOf(step) > i ? "✓" : s.num}
               </div>
-              <span className={`text-sm font-medium ${step === s.id ? "text-white" : "text-gray-500"}`}>
+              <span className={`text-sm font-medium ${step === s.id ? "text-on-surface" : "text-on-surface-variant"}`}>
                 {s.label}
               </span>
-              {i < 2 && <div className="w-12 h-px bg-white/10" />}
+              {i < 2 && <div className="w-12 h-px bg-outline-variant" />}
             </div>
           ))}
         </div>
@@ -199,36 +194,36 @@ function NewDebatePageInner() {
         {step === "input" && (
           <div className="space-y-8">
             <div>
-              <h1 className="text-3xl font-black text-white mb-2">Create a Custom Debate</h1>
-              <p className="text-gray-500">Enter any resolution. Our AI will analyze it and generate research prompts for both sides.</p>
+              <h1 className="text-3xl font-black text-on-surface mb-2">Create a Custom Debate</h1>
+              <p className="text-on-surface-variant">Enter any resolution. Our AI will analyze it and generate research prompts for both sides.</p>
             </div>
 
             <div className="space-y-4">
               <div>
-                <label className="block text-sm font-bold text-gray-400 mb-2">Debate Resolution</label>
+                <label className="block text-sm font-bold text-on-surface-variant mb-2">Debate Resolution</label>
                 <input
                   type="text"
                   value={resolution}
                   onChange={(e) => setResolution(e.target.value)}
                   onKeyDown={(e) => e.key === "Enter" && handleAnalyze()}
                   placeholder="e.g. Should the US ban TikTok?"
-                  className="w-full px-5 py-4 bg-white/[0.03] border border-white/10 rounded-2xl text-white placeholder-gray-600 focus:outline-none focus:border-cyan-500/50 focus:ring-2 focus:ring-cyan-500/10 text-lg"
+                  className="w-full px-5 py-4 bg-surface-container border border-outline-variant rounded-none text-on-surface placeholder-on-surface-variant focus:outline-none focus:border-pro text-lg"
                 />
               </div>
 
               <div>
-                <label className="block text-sm font-bold text-gray-400 mb-2">Additional Context (optional)</label>
+                <label className="block text-sm font-bold text-on-surface-variant mb-2">Additional Context (optional)</label>
                 <textarea
                   value={context}
                   onChange={(e) => setContext(e.target.value)}
                   placeholder="Any specific angle, framing, or context you want the debate to focus on..."
                   rows={3}
-                  className="w-full px-5 py-4 bg-white/[0.03] border border-white/10 rounded-2xl text-white placeholder-gray-600 focus:outline-none focus:border-cyan-500/50 focus:ring-2 focus:ring-cyan-500/10"
+                  className="w-full px-5 py-4 bg-surface-container border border-outline-variant rounded-none text-on-surface placeholder-on-surface-variant focus:outline-none focus:border-pro"
                 />
               </div>
 
               {error && (
-                <div className="p-4 rounded-xl bg-red-500/10 border border-red-500/20 text-red-400 text-sm">
+                <div className="p-4 rounded-none bg-red-500/10 border border-red-500/20 text-red-400 text-sm">
                   {error}
                 </div>
               )}
@@ -236,7 +231,7 @@ function NewDebatePageInner() {
               <button
                 onClick={handleAnalyze}
                 disabled={!resolution.trim() || loading}
-                className="px-8 py-4 bg-gradient-to-r from-cyan-500 to-blue-600 text-white rounded-xl font-bold text-lg transition-all hover:shadow-[0_0_30px_rgba(6,182,212,0.4)] disabled:opacity-50 disabled:cursor-not-allowed"
+                className="px-8 py-4 bg-pro text-[#00195b] rounded-none font-bold text-lg transition-all uppercase tracking-widest disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 {loading ? "Analyzing..." : "Analyze Topic →"}
               </button>
@@ -249,15 +244,15 @@ function NewDebatePageInner() {
           <div className="space-y-10">
             {/* Header */}
             <div>
-              <h1 className="text-3xl font-black text-white mb-3">Research Prompts</h1>
-              <p className="text-gray-400 leading-relaxed max-w-2xl">
+              <h1 className="text-3xl font-black text-on-surface mb-3">Research Prompts</h1>
+              <p className="text-on-surface-variant leading-relaxed max-w-2xl">
                 We&apos;ve analyzed your topic. Follow the steps below to gather deep research for both sides, then upload the results to start your debate.
               </p>
             </div>
 
             {/* How-to Steps */}
-            <div className="rounded-2xl bg-white/[0.03] border border-white/10 p-6">
-              <div className="text-xs font-black uppercase tracking-widest text-gray-500 mb-4">How It Works</div>
+            <div className="rounded-none bg-surface-container border border-outline-variant p-6">
+              <div className="text-xs font-black uppercase tracking-widest text-on-surface-variant mb-4">How It Works</div>
               <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
                 {[
                   { num: "1", icon: "📋", title: "Copy a prompt below", desc: "Each prompt is tailored to research one side of the debate" },
@@ -265,12 +260,12 @@ function NewDebatePageInner() {
                   { num: "3", icon: "📤", title: "Upload the results", desc: "Save as Markdown and upload in the next step" },
                 ].map((s) => (
                   <div key={s.num} className="flex gap-3 items-start">
-                    <div className="w-8 h-8 rounded-lg bg-gradient-to-br from-cyan-500/20 to-blue-600/20 border border-cyan-500/20 flex items-center justify-center text-sm font-black text-cyan-400 shrink-0">
+                    <div className="w-8 h-8 rounded-none bg-pro/20 border border-pro/30 flex items-center justify-center text-sm font-black text-pro shrink-0">
                       {s.num}
                     </div>
                     <div>
-                      <div className="text-sm font-bold text-white mb-0.5">{s.title}</div>
-                      <div className="text-xs text-gray-500 leading-snug">{s.desc}</div>
+                      <div className="text-sm font-bold text-on-surface mb-0.5">{s.title}</div>
+                      <div className="text-xs text-on-surface-variant leading-snug">{s.desc}</div>
                     </div>
                   </div>
                 ))}
@@ -279,96 +274,96 @@ function NewDebatePageInner() {
 
             {/* Position Cards */}
             <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
-              <div className="rounded-2xl bg-gradient-to-br from-cyan-500/[0.08] to-blue-600/[0.04] border border-cyan-500/20 p-5">
+              <div className="rounded-none bg-surface-container border-l-4 border-pro p-5">
                 <div className="flex items-center gap-2 mb-3">
-                  <div className="w-6 h-6 rounded-lg bg-cyan-500/20 flex items-center justify-center text-xs font-black text-cyan-400">P</div>
-                  <span className="text-xs font-black text-cyan-400 uppercase tracking-widest">Pro Position</span>
+                  <div className="w-6 h-6 rounded-none bg-pro/20 flex items-center justify-center text-xs font-black text-pro">P</div>
+                  <span className="text-xs font-black text-pro uppercase tracking-widest">Pro Position</span>
                 </div>
                 <textarea
                   aria-label="Pro position"
                   value={analysis.pro_position}
                   onChange={(e) => setAnalysis({ ...analysis, pro_position: e.target.value })}
                   rows={8}
-                  className="w-full bg-black/20 text-lg text-gray-200 border border-cyan-500/15 rounded-xl px-5 py-4 focus:outline-none focus:border-cyan-500/50 focus:ring-1 focus:ring-cyan-500/20 resize-vertical leading-relaxed"
+                  className="w-full bg-black/20 text-lg text-on-surface border border-pro/15 rounded-none px-5 py-4 focus:outline-none focus:border-pro resize-vertical leading-relaxed"
                 />
               </div>
-              <div className="rounded-2xl bg-gradient-to-br from-fuchsia-500/[0.08] to-purple-600/[0.04] border border-fuchsia-500/20 p-5">
+              <div className="rounded-none bg-surface-container border-l-4 border-con p-5">
                 <div className="flex items-center gap-2 mb-3">
-                  <div className="w-6 h-6 rounded-lg bg-fuchsia-500/20 flex items-center justify-center text-xs font-black text-fuchsia-400">C</div>
-                  <span className="text-xs font-black text-fuchsia-400 uppercase tracking-widest">Con Position</span>
+                  <div className="w-6 h-6 rounded-none bg-con/20 flex items-center justify-center text-xs font-black text-con">C</div>
+                  <span className="text-xs font-black text-con uppercase tracking-widest">Con Position</span>
                 </div>
                 <textarea
                   aria-label="Con position"
                   value={analysis.con_position}
                   onChange={(e) => setAnalysis({ ...analysis, con_position: e.target.value })}
                   rows={8}
-                  className="w-full bg-black/20 text-lg text-gray-200 border border-fuchsia-500/15 rounded-xl px-5 py-4 focus:outline-none focus:border-fuchsia-500/50 focus:ring-1 focus:ring-fuchsia-500/20 resize-vertical leading-relaxed"
+                  className="w-full bg-black/20 text-lg text-on-surface border border-con/15 rounded-none px-5 py-4 focus:outline-none focus:border-con resize-vertical leading-relaxed"
                 />
               </div>
             </div>
 
             {/* Pro Prompt Card */}
-            <div className="rounded-2xl bg-white/[0.02] border border-cyan-500/15 overflow-hidden">
-              <div className="flex items-center justify-between px-6 py-4 border-b border-white/[0.06] bg-cyan-500/[0.04]">
+            <div className="rounded-none bg-surface-container border-l-4 border-pro overflow-hidden">
+              <div className="flex items-center justify-between px-6 py-4 border-b border-outline-variant bg-pro/[0.04]">
                 <div className="flex items-center gap-3">
-                  <div className="w-8 h-8 rounded-lg bg-cyan-500/15 flex items-center justify-center">
-                    <span className="text-cyan-400 text-sm">📋</span>
+                  <div className="w-8 h-8 rounded-none bg-pro/15 flex items-center justify-center">
+                    <span className="text-pro text-sm">📋</span>
                   </div>
                   <div>
-                    <div className="text-sm font-black text-cyan-400">PRO Research Prompt</div>
-                    <div className="text-[11px] text-gray-500">Copy and paste into ChatGPT, Claude, or Gemini</div>
+                    <div className="text-sm font-black text-pro">PRO Research Prompt</div>
+                    <div className="text-[11px] text-on-surface-variant">Copy and paste into ChatGPT, Claude, or Gemini</div>
                   </div>
                 </div>
                 <button
                   onClick={() => copyToClipboard(analysis.pro_prompt, "pro")}
-                  className={`px-5 py-2.5 rounded-xl text-sm font-bold transition-all shrink-0 ${
+                  className={`px-5 py-2.5 rounded-none text-sm font-bold transition-all shrink-0 ${
                     proCopied
-                      ? "bg-emerald-500/20 border border-emerald-500/30 text-emerald-400"
-                      : "bg-cyan-500/10 border border-cyan-500/30 text-cyan-400 hover:bg-cyan-500/20 hover:shadow-[0_0_15px_rgba(6,182,212,0.2)]"
+                      ? "bg-pro/20 border border-pro/30 text-pro"
+                      : "bg-pro/20 border border-pro/30 text-pro hover:bg-pro/30"
                   }`}
                 >
                   {proCopied ? "✓ Copied!" : "Copy to Clipboard"}
                 </button>
               </div>
-              <div className="p-6 max-h-[32rem] overflow-y-auto scrollbar-thin prose prose-invert prose-base max-w-none prose-headings:text-cyan-300 prose-headings:font-black prose-strong:text-gray-200 prose-li:text-gray-300 prose-p:text-gray-300 prose-ul:list-disc prose-ol:list-decimal">
+              <div className="p-6 max-h-[32rem] overflow-y-auto scrollbar-thin prose prose-invert prose-base max-w-none prose-headings:text-pro prose-headings:font-black prose-strong:text-on-surface prose-li:text-on-surface-variant prose-p:text-on-surface-variant prose-ul:list-disc prose-ol:list-decimal">
                 <ReactMarkdown>{analysis.pro_prompt}</ReactMarkdown>
               </div>
             </div>
 
             {/* Con Prompt Card */}
-            <div className="rounded-2xl bg-white/[0.02] border border-fuchsia-500/15 overflow-hidden">
-              <div className="flex items-center justify-between px-6 py-4 border-b border-white/[0.06] bg-fuchsia-500/[0.04]">
+            <div className="rounded-none bg-surface-container border-l-4 border-con overflow-hidden">
+              <div className="flex items-center justify-between px-6 py-4 border-b border-outline-variant bg-con/[0.04]">
                 <div className="flex items-center gap-3">
-                  <div className="w-8 h-8 rounded-lg bg-fuchsia-500/15 flex items-center justify-center">
-                    <span className="text-fuchsia-400 text-sm">📋</span>
+                  <div className="w-8 h-8 rounded-none bg-con/15 flex items-center justify-center">
+                    <span className="text-con text-sm">📋</span>
                   </div>
                   <div>
-                    <div className="text-sm font-black text-fuchsia-400">CON Research Prompt</div>
-                    <div className="text-[11px] text-gray-500">Copy and paste into ChatGPT, Claude, or Gemini</div>
+                    <div className="text-sm font-black text-con">CON Research Prompt</div>
+                    <div className="text-[11px] text-on-surface-variant">Copy and paste into ChatGPT, Claude, or Gemini</div>
                   </div>
                 </div>
                 <button
                   onClick={() => copyToClipboard(analysis.con_prompt, "con")}
-                  className={`px-5 py-2.5 rounded-xl text-sm font-bold transition-all shrink-0 ${
+                  className={`px-5 py-2.5 rounded-none text-sm font-bold transition-all shrink-0 ${
                     conCopied
-                      ? "bg-emerald-500/20 border border-emerald-500/30 text-emerald-400"
-                      : "bg-fuchsia-500/10 border border-fuchsia-500/30 text-fuchsia-400 hover:bg-fuchsia-500/20 hover:shadow-[0_0_15px_rgba(217,70,239,0.2)]"
+                      ? "bg-con/20 border border-con/30 text-con"
+                      : "bg-con/20 border border-con/30 text-con hover:bg-con/30"
                   }`}
                 >
                   {conCopied ? "✓ Copied!" : "Copy to Clipboard"}
                 </button>
               </div>
-              <div className="p-6 max-h-[32rem] overflow-y-auto scrollbar-thin prose prose-invert prose-base max-w-none prose-headings:text-fuchsia-300 prose-headings:font-black prose-strong:text-gray-200 prose-li:text-gray-300 prose-p:text-gray-300 prose-ul:list-disc prose-ol:list-decimal">
+              <div className="p-6 max-h-[32rem] overflow-y-auto scrollbar-thin prose prose-invert prose-base max-w-none prose-headings:text-con prose-headings:font-black prose-strong:text-on-surface prose-li:text-on-surface-variant prose-p:text-on-surface-variant prose-ul:list-disc prose-ol:list-decimal">
                 <ReactMarkdown>{analysis.con_prompt}</ReactMarkdown>
               </div>
             </div>
 
             {/* Internal Research Teaser */}
-            <div className="rounded-2xl bg-gradient-to-r from-amber-500/[0.06] to-orange-500/[0.04] border border-amber-500/20 p-5 flex items-center gap-4">
-              <div className="w-10 h-10 rounded-xl bg-amber-500/15 flex items-center justify-center text-lg shrink-0">🔬</div>
+            <div className="rounded-none bg-surface-container border border-outline-variant p-5 flex items-center gap-4">
+              <div className="w-10 h-10 rounded-none bg-amber-500/15 flex items-center justify-center text-lg shrink-0">🔬</div>
               <div>
                 <div className="text-sm font-bold text-amber-400">Internal AI Research — Coming Soon</div>
-                <div className="text-xs text-gray-500 leading-relaxed">Paid members will be able to skip the manual step — our AI will automatically research both sides for you.</div>
+                <div className="text-xs text-on-surface-variant leading-relaxed">Paid members will be able to skip the manual step — our AI will automatically research both sides for you.</div>
               </div>
             </div>
 
@@ -376,16 +371,16 @@ function NewDebatePageInner() {
             <div className="flex items-center gap-4 pt-2">
               <button
                 onClick={() => setStep("input")}
-                className="px-6 py-3 rounded-xl text-sm font-bold bg-white/5 border border-white/10 text-gray-400 hover:text-white hover:bg-white/10 transition-all"
+                className="px-6 py-3 rounded-none text-sm font-bold bg-surface-container border border-outline-variant text-on-surface-variant hover:text-on-surface hover:bg-surface-high transition-all"
               >
                 ← Back
               </button>
               <button
                 onClick={() => setStep("upload")}
-                className="px-8 py-3.5 bg-gradient-to-r from-cyan-500 to-blue-600 text-white rounded-xl font-bold transition-all hover:shadow-[0_0_30px_rgba(6,182,212,0.4)] flex items-center gap-2"
+                className="px-8 py-3.5 bg-pro text-[#00195b] rounded-none font-bold uppercase tracking-widest transition-all flex items-center gap-2"
               >
                 I&apos;ve Done My Research
-                <span className="text-white/60">→</span>
+                <span className="opacity-60">→</span>
                 Upload Results
               </button>
             </div>
@@ -396,8 +391,8 @@ function NewDebatePageInner() {
         {step === "upload" && analysis && (
           <div className="space-y-8">
             <div>
-              <h1 className="text-3xl font-black text-white mb-3">Upload Research</h1>
-              <p className="text-gray-400 leading-relaxed max-w-2xl">
+              <h1 className="text-3xl font-black text-on-surface mb-3">Upload Research</h1>
+              <p className="text-on-surface-variant leading-relaxed max-w-2xl">
                 Upload or paste the Markdown research generated by your AI tool. Both Pro and Con research are required to start the debate.
               </p>
             </div>
@@ -405,28 +400,28 @@ function NewDebatePageInner() {
             <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
               {/* Pro Upload */}
               {proUploaded ? (
-                <div className="rounded-2xl bg-emerald-500/[0.06] border border-emerald-500/25 p-8 text-center space-y-3">
-                  <div className="w-14 h-14 rounded-2xl bg-emerald-500/15 flex items-center justify-center text-3xl mx-auto">✅</div>
-                  <div className="text-sm font-black text-emerald-400 uppercase tracking-widest">Pro Research Uploaded</div>
-                  <p className="text-xs text-gray-500">Ready for debate</p>
+                <div className="rounded-none bg-pro/[0.06] border border-pro/25 p-8 text-center space-y-3">
+                  <div className="w-14 h-14 rounded-none bg-pro/15 flex items-center justify-center text-3xl mx-auto">✅</div>
+                  <div className="text-sm font-black text-pro uppercase tracking-widest">Pro Research Uploaded</div>
+                  <p className="text-xs text-on-surface-variant">Ready for debate</p>
                 </div>
               ) : (
-                <div className="rounded-2xl bg-white/[0.02] border border-cyan-500/15 overflow-hidden">
-                  <div className="flex items-center justify-between px-5 py-3 border-b border-white/[0.06] bg-cyan-500/[0.04]">
+                <div className="rounded-none bg-surface-container border-l-4 border-pro overflow-hidden">
+                  <div className="flex items-center justify-between px-5 py-3 border-b border-outline-variant bg-pro/[0.04]">
                     <div className="flex items-center gap-2">
-                      <div className="w-6 h-6 rounded-lg bg-cyan-500/20 flex items-center justify-center text-xs font-black text-cyan-400">P</div>
-                      <span className="text-sm font-black text-cyan-400">PRO Research</span>
+                      <div className="w-6 h-6 rounded-none bg-pro/20 flex items-center justify-center text-xs font-black text-pro">P</div>
+                      <span className="text-sm font-black text-pro">PRO Research</span>
                     </div>
-                    <div className="flex rounded-lg overflow-hidden border border-white/10">
+                    <div className="flex rounded-none overflow-hidden border border-outline-variant">
                       <button
                         onClick={() => setProInputMode("file")}
-                        className={`px-3 py-1 text-[11px] font-bold transition-all ${proInputMode === "file" ? "bg-cyan-500/20 text-cyan-400" : "text-gray-500 hover:text-gray-300"}`}
+                        className={`px-3 py-1 text-[11px] font-bold transition-all ${proInputMode === "file" ? "bg-pro/20 text-pro" : "text-on-surface-variant hover:text-on-surface"}`}
                       >
                         File
                       </button>
                       <button
                         onClick={() => setProInputMode("paste")}
-                        className={`px-3 py-1 text-[11px] font-bold transition-all ${proInputMode === "paste" ? "bg-cyan-500/20 text-cyan-400" : "text-gray-500 hover:text-gray-300"}`}
+                        className={`px-3 py-1 text-[11px] font-bold transition-all ${proInputMode === "paste" ? "bg-pro/20 text-pro" : "text-on-surface-variant hover:text-on-surface"}`}
                       >
                         Paste
                       </button>
@@ -438,21 +433,21 @@ function NewDebatePageInner() {
                       onDragOver={handleDragOver("pro")}
                       onDragLeave={handleDragLeave("pro")}
                       onDrop={handleDrop("pro")}
-                      className={`p-8 text-center space-y-4 transition-all cursor-pointer ${
-                        proDragOver ? "bg-cyan-500/10 border-cyan-500/40" : "hover:bg-white/[0.02]"
+                      className={`p-8 text-center space-y-4 transition-all cursor-pointer border-2 border-dashed ${
+                        proDragOver ? "bg-pro/10 border-pro/40" : "border-outline-variant hover:bg-surface-high"
                       }`}
                       onClick={() => proFileRef.current?.click()}
                     >
-                      <div className={`w-14 h-14 rounded-2xl mx-auto flex items-center justify-center text-3xl transition-all ${
-                        proDragOver ? "bg-cyan-500/20 scale-110" : "bg-white/5"
+                      <div className={`w-14 h-14 rounded-none mx-auto flex items-center justify-center text-3xl transition-all ${
+                        proDragOver ? "bg-pro/20 scale-110" : "bg-surface-high"
                       }`}>
                         {proDragOver ? "📥" : "📄"}
                       </div>
                       <div>
-                        <p className="text-sm text-gray-300 font-medium">
+                        <p className="text-sm text-on-surface font-medium">
                           {proDragOver ? "Drop file here" : "Drag & drop your file here"}
                         </p>
-                        <p className="text-xs text-gray-500 mt-1">or click to browse &middot; .md, .txt, .markdown</p>
+                        <p className="text-xs text-on-surface-variant mt-1">or click to browse &middot; .md, .txt, .markdown</p>
                       </div>
                       <input
                         ref={proFileRef}
@@ -473,12 +468,12 @@ function NewDebatePageInner() {
                         onChange={(e) => setProPasteText(e.target.value)}
                         placeholder="Paste your Pro research Markdown here..."
                         rows={8}
-                        className="w-full bg-black/30 text-sm text-gray-300 border border-cyan-500/15 rounded-xl px-4 py-3 focus:outline-none focus:border-cyan-500/50 focus:ring-1 focus:ring-cyan-500/20 resize-none font-mono placeholder-gray-600"
+                        className="w-full bg-black/30 text-sm text-on-surface border border-pro/15 rounded-none px-4 py-3 focus:outline-none focus:border-pro resize-none font-mono placeholder-on-surface-variant"
                       />
                       <button
                         onClick={() => handlePasteUpload("pro")}
                         disabled={!proPasteText.trim() || uploading}
-                        className="w-full px-4 py-2.5 rounded-xl text-sm font-bold bg-cyan-500/10 border border-cyan-500/30 text-cyan-400 hover:bg-cyan-500/20 transition-all disabled:opacity-40 disabled:cursor-not-allowed"
+                        className="w-full px-4 py-2.5 rounded-none text-sm font-bold bg-pro/20 border border-pro/30 text-pro hover:bg-pro/30 transition-all disabled:opacity-40 disabled:cursor-not-allowed"
                       >
                         {uploading ? "Uploading..." : "Upload Pasted Content"}
                       </button>
@@ -489,28 +484,28 @@ function NewDebatePageInner() {
 
               {/* Con Upload */}
               {conUploaded ? (
-                <div className="rounded-2xl bg-emerald-500/[0.06] border border-emerald-500/25 p-8 text-center space-y-3">
-                  <div className="w-14 h-14 rounded-2xl bg-emerald-500/15 flex items-center justify-center text-3xl mx-auto">✅</div>
-                  <div className="text-sm font-black text-emerald-400 uppercase tracking-widest">Con Research Uploaded</div>
-                  <p className="text-xs text-gray-500">Ready for debate</p>
+                <div className="rounded-none bg-pro/[0.06] border border-pro/25 p-8 text-center space-y-3">
+                  <div className="w-14 h-14 rounded-none bg-pro/15 flex items-center justify-center text-3xl mx-auto">✅</div>
+                  <div className="text-sm font-black text-pro uppercase tracking-widest">Con Research Uploaded</div>
+                  <p className="text-xs text-on-surface-variant">Ready for debate</p>
                 </div>
               ) : (
-                <div className="rounded-2xl bg-white/[0.02] border border-fuchsia-500/15 overflow-hidden">
-                  <div className="flex items-center justify-between px-5 py-3 border-b border-white/[0.06] bg-fuchsia-500/[0.04]">
+                <div className="rounded-none bg-surface-container border-l-4 border-con overflow-hidden">
+                  <div className="flex items-center justify-between px-5 py-3 border-b border-outline-variant bg-con/[0.04]">
                     <div className="flex items-center gap-2">
-                      <div className="w-6 h-6 rounded-lg bg-fuchsia-500/20 flex items-center justify-center text-xs font-black text-fuchsia-400">C</div>
-                      <span className="text-sm font-black text-fuchsia-400">CON Research</span>
+                      <div className="w-6 h-6 rounded-none bg-con/20 flex items-center justify-center text-xs font-black text-con">C</div>
+                      <span className="text-sm font-black text-con">CON Research</span>
                     </div>
-                    <div className="flex rounded-lg overflow-hidden border border-white/10">
+                    <div className="flex rounded-none overflow-hidden border border-outline-variant">
                       <button
                         onClick={() => setConInputMode("file")}
-                        className={`px-3 py-1 text-[11px] font-bold transition-all ${conInputMode === "file" ? "bg-fuchsia-500/20 text-fuchsia-400" : "text-gray-500 hover:text-gray-300"}`}
+                        className={`px-3 py-1 text-[11px] font-bold transition-all ${conInputMode === "file" ? "bg-con/20 text-con" : "text-on-surface-variant hover:text-on-surface"}`}
                       >
                         File
                       </button>
                       <button
                         onClick={() => setConInputMode("paste")}
-                        className={`px-3 py-1 text-[11px] font-bold transition-all ${conInputMode === "paste" ? "bg-fuchsia-500/20 text-fuchsia-400" : "text-gray-500 hover:text-gray-300"}`}
+                        className={`px-3 py-1 text-[11px] font-bold transition-all ${conInputMode === "paste" ? "bg-con/20 text-con" : "text-on-surface-variant hover:text-on-surface"}`}
                       >
                         Paste
                       </button>
@@ -522,21 +517,21 @@ function NewDebatePageInner() {
                       onDragOver={handleDragOver("con")}
                       onDragLeave={handleDragLeave("con")}
                       onDrop={handleDrop("con")}
-                      className={`p-8 text-center space-y-4 transition-all cursor-pointer ${
-                        conDragOver ? "bg-fuchsia-500/10 border-fuchsia-500/40" : "hover:bg-white/[0.02]"
+                      className={`p-8 text-center space-y-4 transition-all cursor-pointer border-2 border-dashed ${
+                        conDragOver ? "bg-con/10 border-con/40" : "border-outline-variant hover:bg-surface-high"
                       }`}
                       onClick={() => conFileRef.current?.click()}
                     >
-                      <div className={`w-14 h-14 rounded-2xl mx-auto flex items-center justify-center text-3xl transition-all ${
-                        conDragOver ? "bg-fuchsia-500/20 scale-110" : "bg-white/5"
+                      <div className={`w-14 h-14 rounded-none mx-auto flex items-center justify-center text-3xl transition-all ${
+                        conDragOver ? "bg-con/20 scale-110" : "bg-surface-high"
                       }`}>
                         {conDragOver ? "📥" : "📄"}
                       </div>
                       <div>
-                        <p className="text-sm text-gray-300 font-medium">
+                        <p className="text-sm text-on-surface font-medium">
                           {conDragOver ? "Drop file here" : "Drag & drop your file here"}
                         </p>
-                        <p className="text-xs text-gray-500 mt-1">or click to browse &middot; .md, .txt, .markdown</p>
+                        <p className="text-xs text-on-surface-variant mt-1">or click to browse &middot; .md, .txt, .markdown</p>
                       </div>
                       <input
                         ref={conFileRef}
@@ -557,12 +552,12 @@ function NewDebatePageInner() {
                         onChange={(e) => setConPasteText(e.target.value)}
                         placeholder="Paste your Con research Markdown here..."
                         rows={8}
-                        className="w-full bg-black/30 text-sm text-gray-300 border border-fuchsia-500/15 rounded-xl px-4 py-3 focus:outline-none focus:border-fuchsia-500/50 focus:ring-1 focus:ring-fuchsia-500/20 resize-none font-mono placeholder-gray-600"
+                        className="w-full bg-black/30 text-sm text-on-surface border border-con/15 rounded-none px-4 py-3 focus:outline-none focus:border-con resize-none font-mono placeholder-on-surface-variant"
                       />
                       <button
                         onClick={() => handlePasteUpload("con")}
                         disabled={!conPasteText.trim() || uploading}
-                        className="w-full px-4 py-2.5 rounded-xl text-sm font-bold bg-fuchsia-500/10 border border-fuchsia-500/30 text-fuchsia-400 hover:bg-fuchsia-500/20 transition-all disabled:opacity-40 disabled:cursor-not-allowed"
+                        className="w-full px-4 py-2.5 rounded-none text-sm font-bold bg-con/20 border border-con/30 text-con hover:bg-con/30 transition-all disabled:opacity-40 disabled:cursor-not-allowed"
                       >
                         {uploading ? "Uploading..." : "Upload Pasted Content"}
                       </button>
@@ -573,7 +568,7 @@ function NewDebatePageInner() {
             </div>
 
             {error && (
-              <div className="p-4 rounded-xl bg-red-500/10 border border-red-500/20 text-red-400 text-sm">
+              <div className="p-4 rounded-none bg-red-500/10 border border-red-500/20 text-red-400 text-sm">
                 {error}
               </div>
             )}
@@ -581,14 +576,14 @@ function NewDebatePageInner() {
             <div className="flex items-center gap-4 pt-2">
               <button
                 onClick={() => setStep("research")}
-                className="px-6 py-3 rounded-xl text-sm font-bold bg-white/5 border border-white/10 text-gray-400 hover:text-white hover:bg-white/10 transition-all"
+                className="px-6 py-3 rounded-none text-sm font-bold bg-surface-container border border-outline-variant text-on-surface-variant hover:text-on-surface hover:bg-surface-high transition-all"
               >
                 ← Back to Prompts
               </button>
               <button
                 onClick={handleStartDebate}
                 disabled={!proUploaded || !conUploaded}
-                className="px-8 py-4 bg-gradient-to-r from-emerald-500 to-cyan-500 text-white rounded-xl font-bold text-lg transition-all hover:shadow-[0_0_30px_rgba(16,185,129,0.4)] disabled:opacity-30 disabled:cursor-not-allowed"
+                className="px-8 py-4 bg-pro text-[#00195b] rounded-none font-bold text-lg uppercase tracking-widest transition-all disabled:opacity-30 disabled:cursor-not-allowed"
               >
                 Start Debate →
               </button>
@@ -603,8 +598,8 @@ function NewDebatePageInner() {
 export default function NewDebatePage() {
   return (
     <Suspense fallback={
-      <div className="min-h-screen bg-slate-950 flex items-center justify-center">
-        <div className="w-8 h-8 rounded-full border-2 border-cyan-400 border-t-transparent animate-spin" />
+      <div className="min-h-screen bg-surface flex items-center justify-center">
+        <div className="w-8 h-8 rounded-none border-2 border-pro border-t-transparent animate-spin" />
       </div>
     }>
       <NewDebatePageInner />

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1,37 +1,90 @@
 @import "tailwindcss";
+@import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;400;500;600;700&family=Newsreader:ital,opsz,wght@0,6..72,300;0,6..72,400;0,6..72,500;1,6..72,300;1,6..72,400&family=Inter:wght@300;400;500;600;700&display=swap');
 @plugin "@tailwindcss/typography";
 
+/* ── Design Tokens ── */
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
+  --surface: #0e0e0e;
+  --surface-low: #131313;
+  --surface-container: #191a1a;
+  --surface-high: #1f2020;
+  --surface-highest: #252626;
+  --surface-bright: #2b2c2c;
+
+  --on-surface: #e7e5e5;
+  --on-surface-variant: #acabaa;
+
+  --primary: #c6c6c7;
+  --on-primary: #3f4041;
+
+  --secondary: #7c98ff;
+  --on-secondary: #00195b;
+
+  --tertiary: #ff7168;
+  --on-tertiary: #4a0004;
+
+  --outline: #767575;
+  --outline-variant: #484848;
+
+  --background: #0e0e0e;
+  --foreground: #e7e5e5;
+
+  --font-headline: 'Space Grotesk', sans-serif;
+  --font-body: 'Newsreader', Georgia, serif;
+  --font-label: 'Inter', system-ui, sans-serif;
 }
 
 @theme inline {
+  --color-surface: var(--surface);
+  --color-surface-low: var(--surface-low);
+  --color-surface-container: var(--surface-container);
+  --color-surface-high: var(--surface-high);
+  --color-surface-highest: var(--surface-highest);
+  --color-surface-bright: var(--surface-bright);
+  --color-on-surface: var(--on-surface);
+  --color-on-surface-variant: var(--on-surface-variant);
+  --color-primary: var(--primary);
+  --color-on-primary: var(--on-primary);
+  --color-pro: var(--secondary);
+  --color-con: var(--tertiary);
+  --color-outline: var(--outline);
+  --color-outline-variant: var(--outline-variant);
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
+  --font-sans: var(--font-label);
+  --font-headline: var(--font-headline);
+  --font-body: var(--font-body);
 }
 
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-label);
 }
 
+/* ── Scrollbar ── */
+::-webkit-scrollbar { width: 4px; }
+::-webkit-scrollbar-track { background: var(--surface); }
+::-webkit-scrollbar-thumb { background: var(--surface-highest); border-radius: 0; }
+::-webkit-scrollbar-thumb:hover { background: var(--primary); }
+
+/* ── Keyframes ── */
 @keyframes fadeIn {
-  from { opacity: 0; transform: scale(0.95); }
-  to { opacity: 1; transform: scale(1); }
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
 }
-
 @keyframes slideUp {
   from { opacity: 0; transform: translateY(30px); }
   to { opacity: 1; transform: translateY(0); }
 }
+@keyframes stream-cursor {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0; }
+}
+
+/* ── Helpers ── */
+.font-headline { font-family: var(--font-headline); }
+.font-body { font-family: var(--font-body); }
+.font-label { font-family: var(--font-label); }
+
+.border-sharp { border-radius: 0 !important; }

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1,5 +1,5 @@
-@import "tailwindcss";
 @import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;400;500;600;700&family=Newsreader:ital,opsz,wght@0,6..72,300;0,6..72,400;0,6..72,500;1,6..72,300;1,6..72,400&family=Inter:wght@300;400;500;600;700&display=swap');
+@import "tailwindcss";
 @plugin "@tailwindcss/typography";
 
 /* ── Design Tokens ── */

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -29,9 +29,6 @@
   --background: #0e0e0e;
   --foreground: #e7e5e5;
 
-  --font-headline: 'Space Grotesk', sans-serif;
-  --font-body: 'Newsreader', Georgia, serif;
-  --font-label: 'Inter', system-ui, sans-serif;
 }
 
 @theme inline {
@@ -51,15 +48,16 @@
   --color-outline-variant: var(--outline-variant);
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-label);
-  --font-headline: var(--font-headline);
-  --font-body: var(--font-body);
+  /* Fonts defined directly here (not via var) to avoid circular references */
+  --font-sans: 'Inter', system-ui, sans-serif;
+  --font-headline: 'Space Grotesk', sans-serif;
+  --font-body: 'Newsreader', Georgia, serif;
 }
 
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: var(--font-label);
+  font-family: var(--font-sans);
 }
 
 /* ── Scrollbar ── */
@@ -85,6 +83,6 @@ body {
 /* ── Helpers ── */
 .font-headline { font-family: var(--font-headline); }
 .font-body { font-family: var(--font-body); }
-.font-label { font-family: var(--font-label); }
+.font-label { font-family: var(--font-sans); }
 
 .border-sharp { border-radius: 0 !important; }

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,16 +1,5 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
-
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
 
 export const metadata: Metadata = {
   title: "DebateMeBro - AI Debate Engine",
@@ -24,9 +13,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased bg-gray-950 text-gray-100 min-h-screen flex flex-col`}
-      >
+      <body className="antialiased bg-surface text-on-surface min-h-screen flex flex-col font-label">
         {children}
       </body>
     </html>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -154,8 +154,8 @@ function HomeInner() {
           {/* Badge */}
           <div className="inline-flex items-center gap-2 px-5 py-2 rounded-none bg-surface-high border border-outline-variant mb-10">
             <span className="relative flex h-2.5 w-2.5">
-              <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-pro opacity-75" />
-              <span className="relative inline-flex rounded-full h-2.5 w-2.5 bg-pro" />
+              <span className="animate-ping absolute inline-flex h-full w-full rounded-none bg-pro opacity-75" />
+              <span className="relative inline-flex rounded-none h-2.5 w-2.5 bg-pro" />
             </span>
             <span className="text-xs font-bold text-on-surface-variant uppercase tracking-widest">Live AI Debate Engine</span>
           </div>
@@ -229,7 +229,7 @@ function HomeInner() {
               <div className="flex flex-wrap gap-4 justify-center min-h-[48px]">
                 {loading ? (
                   <div className="flex items-center gap-3 text-sm font-medium text-pro">
-                    <span className="w-5 h-5 border-2 border-pro/30 border-t-pro rounded-full animate-spin" />
+                    <span className="w-5 h-5 border-2 border-pro/30 border-t-pro rounded-none animate-spin" />
                     Loading presets...
                   </div>
                 ) : (

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -111,45 +111,37 @@ function HomeInner() {
   };
 
   return (
-    <div className="min-h-screen bg-slate-950 text-gray-100 flex flex-col relative font-sans overflow-hidden">
-      {/* Animated Background */}
-      <div className="absolute inset-0 pointer-events-none overflow-hidden z-0">
-        <div className="absolute -top-[10%] -left-[10%] w-[60vw] h-[60vw] bg-fuchsia-600/20 blur-[120px] rounded-full mix-blend-screen animate-[pulse_8s_ease-in-out_infinite]" />
-        <div className="absolute top-[30%] -right-[15%] w-[70vw] h-[70vw] bg-blue-600/20 blur-[120px] rounded-full mix-blend-screen animate-[pulse_10s_ease-in-out_infinite_1s]" />
-        <div className="absolute -bottom-[20%] left-[20%] w-[50vw] h-[50vw] bg-violet-600/20 blur-[120px] rounded-full mix-blend-screen animate-[pulse_9s_ease-in-out_infinite_2s]" />
-        <div className="absolute top-[60%] right-[10%] w-[30vw] h-[30vw] bg-cyan-600/10 blur-[100px] rounded-full mix-blend-screen animate-[pulse_12s_ease-in-out_infinite_3s]" />
-      </div>
-
+    <div className="min-h-screen bg-surface text-on-surface flex flex-col relative font-sans">
       {/* Header */}
-      <header className="relative z-10 border-b border-white/10 bg-black/40 backdrop-blur-3xl px-8 py-5 flex items-center justify-between shadow-sm">
+      <header className="relative z-10 border-b border-outline-variant bg-surface-low px-8 py-5 flex items-center justify-between shadow-sm">
         <div className="flex items-center gap-3">
-          <div className="w-8 h-8 rounded-xl bg-gradient-to-br from-cyan-400 via-blue-500 to-purple-600 flex items-center justify-center shadow-[0_0_20px_rgba(56,189,248,0.5)]">
-            <span className="text-white font-bold text-sm">🎯</span>
+          <div className="w-8 h-8 bg-pro flex items-center justify-center">
+            <span className="text-[#00195b] font-bold text-sm">🎯</span>
           </div>
-          <span className="text-xl font-black tracking-tighter bg-clip-text text-transparent bg-gradient-to-r from-white to-gray-400">
+          <span className="text-xl font-black tracking-tighter text-on-surface font-headline">
             DebateMeBro
           </span>
         </div>
         <div className="flex items-center gap-5">
-          <Link href="/browse" className="text-sm font-medium text-gray-400 hover:text-white transition-colors">
+          <Link href="/browse" className="text-sm font-medium text-on-surface-variant hover:text-on-surface transition-colors">
             Browse
           </Link>
           {isLoggedIn ? (
             <>
-              <Link href="/dashboard" className="text-sm font-medium text-gray-300 hover:text-white transition-colors">
+              <Link href="/dashboard" className="text-sm font-medium text-on-surface-variant hover:text-on-surface transition-colors">
                 My Debates
               </Link>
               <div className="flex items-center gap-3">
-                <div className="w-8 h-8 rounded-full bg-gradient-to-br from-fuchsia-500 to-purple-600 flex items-center justify-center text-xs font-black text-white uppercase">
+                <div className="w-8 h-8 bg-con flex items-center justify-center text-xs font-black text-[#00195b] uppercase">
                   {userEmail?.[0] || "U"}
                 </div>
-                <button onClick={handleLogout} className="text-xs font-bold text-gray-500 hover:text-gray-300 transition-colors">
+                <button onClick={handleLogout} className="text-xs font-bold text-on-surface-variant hover:text-on-surface transition-colors">
                   Logout
                 </button>
               </div>
             </>
           ) : (
-            <Link href="/auth" className="text-sm font-bold text-white bg-white/10 hover:bg-white/20 border border-white/20 px-6 py-2.5 rounded-full transition-all hover:shadow-[0_0_20px_rgba(255,255,255,0.15)] hover:scale-105">
+            <Link href="/auth" className="text-sm font-bold text-on-surface-variant hover:text-on-surface border border-outline-variant hover:border-outline px-4 py-2 rounded-none transition-colors">
               Sign In
             </Link>
           )}
@@ -160,30 +152,30 @@ function HomeInner() {
         {/* ═══ Hero Section ═══ */}
         <section className="flex flex-col items-center justify-center px-6 max-w-6xl mx-auto text-center pt-20 pb-16 w-full">
           {/* Badge */}
-          <div className="inline-flex items-center gap-2 px-5 py-2 rounded-full bg-white/10 border border-white/20 mb-10 backdrop-blur-md shadow-[0_8px_32px_0_rgba(31,38,135,0.37)]">
+          <div className="inline-flex items-center gap-2 px-5 py-2 rounded-none bg-surface-high border border-outline-variant mb-10">
             <span className="relative flex h-2.5 w-2.5">
-              <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-cyan-400 opacity-75" />
-              <span className="relative inline-flex rounded-full h-2.5 w-2.5 bg-cyan-500" />
+              <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-pro opacity-75" />
+              <span className="relative inline-flex rounded-full h-2.5 w-2.5 bg-pro" />
             </span>
-            <span className="text-xs font-bold text-cyan-300 uppercase tracking-widest">Live AI Debate Engine</span>
+            <span className="text-xs font-bold text-on-surface-variant uppercase tracking-widest">Live AI Debate Engine</span>
           </div>
 
-          <h1 className="text-5xl md:text-8xl font-black mb-8 tracking-tighter text-white drop-shadow-2xl leading-tight">
+          <h1 className="text-5xl md:text-8xl font-black mb-8 tracking-tighter text-on-surface leading-tight font-headline">
             See Both Sides.<br />
-            <span className="bg-gradient-to-r from-fuchsia-500 via-violet-500 to-cyan-500 bg-clip-text text-transparent drop-shadow-lg animate-[pulse_4s_ease-in-out_infinite]">
+            <span className="text-on-surface font-headline">
               For Real.
             </span>
           </h1>
 
-          <p className="text-gray-300 text-lg md:text-2xl mb-14 max-w-3xl leading-relaxed font-light">
-            Pick any topic. Two AI agents independently research <strong className="text-white font-semibold">both sides</strong>, build their own strategies, then argue it out live — citing real sources, steelmanning opponents, and getting scored by an impartial judging panel.
+          <p className="text-on-surface-variant text-lg md:text-2xl mb-14 max-w-3xl leading-relaxed font-light font-body">
+            Pick any topic. Two AI agents independently research <strong className="text-on-surface font-semibold">both sides</strong>, build their own strategies, then argue it out live — citing real sources, steelmanning opponents, and getting scored by an impartial judging panel.
           </p>
 
           {/* Topic Input */}
           <div className="w-full max-w-3xl mb-14 relative">
-            <div className="relative group rounded-[2rem] p-2 bg-gradient-to-b from-white/20 to-white/5 backdrop-blur-3xl border border-white/30 transition-all duration-500 hover:border-cyan-500/50 hover:shadow-[0_0_50px_-10px_rgba(6,182,212,0.5)] focus-within:border-cyan-500/50 focus-within:ring-4 focus-within:ring-cyan-500/20 focus-within:shadow-[0_0_50px_-10px_rgba(6,182,212,0.5)] z-20">
-              <div className="relative flex items-center w-full bg-slate-950/60 rounded-3xl overflow-hidden shadow-inner">
-                <span className="pl-6 text-2xl drop-shadow-lg">💡</span>
+            <div className="relative group p-2 bg-surface-container border border-outline-variant transition-all duration-300 hover:border-outline focus-within:border-pro z-20">
+              <div className="relative flex items-center w-full bg-surface rounded-none overflow-hidden">
+                <span className="pl-6 text-2xl">💡</span>
                 <input
                   ref={topicInputRef}
                   type="text"
@@ -199,12 +191,12 @@ function HomeInner() {
                   }}
                   onKeyDown={(e) => e.key === "Enter" && handleStartDebate()}
                   placeholder="Enter any debate topic or statement..."
-                  className="w-full bg-transparent pl-4 pr-44 py-6 text-xl text-white placeholder-gray-400 focus:outline-none transition-all font-medium"
+                  className="w-full bg-transparent pl-4 pr-44 py-6 text-xl text-on-surface placeholder-on-surface-variant focus:outline-none transition-all font-medium"
                   aria-label="Debate topic input"
                 />
                 <button
                   onClick={() => handleStartDebate()}
-                  className="absolute right-3 top-3 bottom-3 bg-gradient-to-r from-cyan-500 to-blue-600 text-white hover:from-cyan-400 hover:to-blue-500 px-8 rounded-2xl font-bold text-base transition-all shadow-[0_4px_20px_rgba(6,182,212,0.4)] hover:shadow-[0_8px_30px_rgba(6,182,212,0.6)] hover:-translate-y-1 active:translate-y-0"
+                  className="absolute right-3 top-3 bottom-3 bg-pro text-[#00195b] hover:opacity-90 px-8 rounded-none font-bold text-base transition-all"
                   aria-label="Start Debate"
                 >
                   Debate It &rarr;
@@ -213,31 +205,31 @@ function HomeInner() {
             </div>
 
             {!isLoggedIn && (
-              <p className="text-xs text-gray-500 mt-3 text-center">
-                <Link href="/auth" className="text-cyan-500 hover:text-cyan-400 font-bold transition-colors">Sign in</Link> to start debating
+              <p className="text-xs text-on-surface-variant mt-3 text-center">
+                <Link href="/auth" className="text-pro hover:opacity-80 font-bold transition-colors">Sign in</Link> to start debating
               </p>
             )}
             {isLoggedIn && usage && !usage.is_admin && (
-              <p className="text-xs text-gray-500 mt-3 text-center">
-                <span className={`font-bold ${usage.remaining > 0 ? "text-cyan-400" : "text-red-400"}`}>
+              <p className="text-xs text-on-surface-variant mt-3 text-center">
+                <span className={`font-bold ${usage.remaining > 0 ? "text-pro" : "text-con"}`}>
                   {usage.used} of {usage.limit}
                 </span>{" "}
                 debates used{usage.remaining === 0 && " — limit reached"}
               </p>
             )}
             {isLoggedIn && usage && usage.is_admin && (
-              <p className="text-xs text-gray-500 mt-3 text-center">
+              <p className="text-xs text-on-surface-variant mt-3 text-center">
                 <span className="font-bold text-amber-400">Admin</span> — unlimited debates
               </p>
             )}
 
             {/* Preset Topics */}
             <div className="mt-10 relative z-20">
-              <p className="text-xs text-gray-400 mb-5 font-bold uppercase tracking-widest drop-shadow-md">Or choose a preset topic</p>
+              <p className="text-xs text-on-surface-variant mb-5 font-bold uppercase tracking-widest">Or choose a preset topic</p>
               <div className="flex flex-wrap gap-4 justify-center min-h-[48px]">
                 {loading ? (
-                  <div className="flex items-center gap-3 text-sm font-medium text-cyan-400">
-                    <span className="w-5 h-5 border-2 border-cyan-500/30 border-t-cyan-400 rounded-full animate-spin" />
+                  <div className="flex items-center gap-3 text-sm font-medium text-pro">
+                    <span className="w-5 h-5 border-2 border-pro/30 border-t-pro rounded-full animate-spin" />
                     Loading presets...
                   </div>
                 ) : (
@@ -245,7 +237,7 @@ function HomeInner() {
                     <button
                       key={preset.id}
                       onClick={() => handleStartDebate(preset)}
-                      className="text-sm font-bold text-white bg-white/10 backdrop-blur-xl border border-white/20 px-6 py-3 rounded-full hover:bg-white/20 hover:border-white/40 transition-all shadow-[0_4px_15px_rgba(0,0,0,0.2)] hover:shadow-[0_0_20px_rgba(255,255,255,0.2)] hover:-translate-y-1"
+                      className="text-sm font-bold text-on-surface bg-surface-container border border-outline-variant px-6 py-3 rounded-none hover:bg-surface-high hover:border-outline transition-colors"
                       aria-label={`Preset topic: ${preset.title}`}
                     >
                       {preset.title}
@@ -260,10 +252,10 @@ function HomeInner() {
         {/* ═══ What Makes This Different ═══ */}
         <section className="px-6 py-20 max-w-6xl mx-auto w-full">
           <div className="text-center mb-16">
-            <h2 className="text-3xl md:text-5xl font-black text-white mb-4 tracking-tight">
+            <h2 className="text-3xl md:text-5xl font-black text-on-surface mb-4 tracking-tight font-headline">
               Not your average AI chatbot.
             </h2>
-            <p className="text-gray-400 text-lg max-w-2xl mx-auto leading-relaxed">
+            <p className="text-on-surface-variant text-lg max-w-2xl mx-auto leading-relaxed font-body">
               Most AI tools give you one answer. We give you two experts arguing their hardest — with real sources you can verify.
             </p>
           </div>
@@ -274,53 +266,45 @@ function HomeInner() {
                 icon: "🧬",
                 title: "Dynamic Personas",
                 desc: "Each debate generates unique AI advocates — a health economist vs. a policy researcher, an IP attorney vs. a digital rights advocate — tailored to the specific topic and evidence.",
-                gradient: "from-cyan-500 to-blue-600",
-                border: "border-cyan-500/20",
+                accent: "border-pro",
               },
               {
                 icon: "📚",
                 title: "Real Research, Real Sources",
                 desc: "Agents cite actual studies, reports, and data with clickable source links. Every claim is traceable. No hallucination, no hand-waving.",
-                gradient: "from-blue-500 to-indigo-600",
-                border: "border-blue-500/20",
+                accent: "border-pro",
               },
               {
                 icon: "🤝",
                 title: "Steelman Requirement",
                 desc: "Before attacking, each agent must restate the opponent's best argument in its strongest form. No strawmanning allowed — intellectual honesty is enforced.",
-                gradient: "from-indigo-500 to-purple-600",
-                border: "border-indigo-500/20",
+                accent: "border-pro",
               },
               {
                 icon: "⚔️",
                 title: "Multi-Round Structure",
                 desc: "Opening → Rebuttal → Closing. Each agent sees all research, sees the opponent's arguments, and responds directly. No talking past each other.",
-                gradient: "from-purple-500 to-fuchsia-600",
-                border: "border-purple-500/20",
+                accent: "border-con",
               },
               {
                 icon: "📊",
                 title: "Transparent Judging",
                 desc: "Three specialized AI judges score Logic, Evidence, and Engagement separately. You see the rubric, the reasoning, and the scores — not a black box.",
-                gradient: "from-fuchsia-500 to-pink-600",
-                border: "border-fuchsia-500/20",
+                accent: "border-con",
               },
               {
                 icon: "🗳️",
                 title: "Your Vote Matters",
                 desc: "After the AI judges, you cast your own vote. See how the crowd agrees or disagrees with the panel. Human judgment meets AI analysis.",
-                gradient: "from-pink-500 to-rose-600",
-                border: "border-pink-500/20",
+                accent: "border-con",
               },
             ].map((f) => (
-              <div key={f.title} className={`group relative flex flex-col p-8 rounded-3xl bg-white/[0.03] border ${f.border} hover:bg-white/[0.06] backdrop-blur-xl transition-all duration-500 hover:-translate-y-2 hover:shadow-[0_20px_60px_-15px_rgba(255,255,255,0.08)]`}>
-                <div className={`w-14 h-14 rounded-2xl bg-gradient-to-br ${f.gradient} p-[2px] mb-6 shadow-lg group-hover:scale-110 transition-transform duration-500`}>
-                  <div className="w-full h-full bg-slate-950/90 rounded-[14px] flex items-center justify-center text-2xl">
-                    {f.icon}
-                  </div>
+              <div key={f.title} className={`group relative flex flex-col p-8 rounded-none bg-surface-container border-l-2 ${f.accent} border border-outline-variant hover:bg-surface-high transition-colors duration-300`}>
+                <div className="w-14 h-14 bg-surface-high flex items-center justify-center text-2xl mb-6">
+                  {f.icon}
                 </div>
-                <h3 className="font-black text-lg text-white mb-3">{f.title}</h3>
-                <p className="text-sm text-gray-400 leading-relaxed flex-1">{f.desc}</p>
+                <h3 className="font-black text-lg text-on-surface mb-3 font-headline">{f.title}</h3>
+                <p className="text-sm text-on-surface-variant leading-relaxed flex-1 font-body">{f.desc}</p>
               </div>
             ))}
           </div>
@@ -329,36 +313,36 @@ function HomeInner() {
         {/* ═══ How It Works ═══ */}
         <section className="px-6 py-20 max-w-5xl mx-auto w-full">
           <div className="text-center mb-16">
-            <h2 className="text-3xl md:text-5xl font-black text-white mb-4 tracking-tight">
+            <h2 className="text-3xl md:text-5xl font-black text-on-surface mb-4 tracking-tight font-headline">
               How a debate unfolds
             </h2>
-            <p className="text-gray-400 text-lg max-w-2xl mx-auto">
+            <p className="text-on-surface-variant text-lg max-w-2xl mx-auto font-body">
               Seven phases, fully automated. You watch it happen live.
             </p>
           </div>
 
           <div className="space-y-4">
             {[
-              { phase: "1", label: "Research", icon: "🔍", desc: "Both agents receive the complete evidence bundle — Pro and Con research. They analyze strengths, vulnerabilities, and build strategy.", bgClass: "bg-cyan-500/10", borderClass: "border-cyan-500/20", internal: false },
-              { phase: "2", label: "Opening Arguments", icon: "📖", desc: "Each agent delivers a compelling opening statement — grounded in evidence, connected to values, streamed to you live.", bgClass: "bg-blue-500/10", borderClass: "border-blue-500/20", internal: false },
-              { phase: "3", label: "Strategic Evaluation", icon: "🧠", desc: "Agents privately analyze the opponent's opening, identify weaknesses, and plan their rebuttal. Viewable via toggle.", bgClass: "bg-purple-500/10", borderClass: "border-purple-500/20", internal: true },
-              { phase: "4", label: "Rebuttals", icon: "⚔️", desc: "Steelman the opponent's best point, then dismantle their weakest. Introduce new evidence. Challenge their sources.", bgClass: "bg-fuchsia-500/10", borderClass: "border-fuchsia-500/20", internal: false },
-              { phase: "5", label: "Full Debate Evaluation", icon: "🧠", desc: "Agents step back and assess the entire debate. What narrowed? What's unresolved? How to close with maximum impact.", bgClass: "bg-pink-500/10", borderClass: "border-pink-500/20", internal: true },
-              { phase: "6", label: "Closing Statements", icon: "🏁", desc: "Synthesize, don't repeat. Acknowledge the opponent. Address the hardest question. Close with impact.", bgClass: "bg-rose-500/10", borderClass: "border-rose-500/20", internal: false },
-              { phase: "7", label: "Judging", icon: "📊", desc: "Three specialized judges (Logic, Evidence, Engagement) score independently. Position-swapped for bias detection.", bgClass: "bg-amber-500/10", borderClass: "border-amber-500/20", internal: false },
+              { phase: "1", label: "Research", icon: "🔍", desc: "Both agents receive the complete evidence bundle — Pro and Con research. They analyze strengths, vulnerabilities, and build strategy.", bgClass: "bg-pro/10", borderClass: "border-pro/30", internal: false },
+              { phase: "2", label: "Opening Arguments", icon: "📖", desc: "Each agent delivers a compelling opening statement — grounded in evidence, connected to values, streamed to you live.", bgClass: "bg-pro/10", borderClass: "border-pro/30", internal: false },
+              { phase: "3", label: "Strategic Evaluation", icon: "🧠", desc: "Agents privately analyze the opponent's opening, identify weaknesses, and plan their rebuttal. Viewable via toggle.", bgClass: "bg-surface-high", borderClass: "border-outline-variant", internal: true },
+              { phase: "4", label: "Rebuttals", icon: "⚔️", desc: "Steelman the opponent's best point, then dismantle their weakest. Introduce new evidence. Challenge their sources.", bgClass: "bg-con/10", borderClass: "border-con/30", internal: false },
+              { phase: "5", label: "Full Debate Evaluation", icon: "🧠", desc: "Agents step back and assess the entire debate. What narrowed? What's unresolved? How to close with maximum impact.", bgClass: "bg-surface-high", borderClass: "border-outline-variant", internal: true },
+              { phase: "6", label: "Closing Statements", icon: "🏁", desc: "Synthesize, don't repeat. Acknowledge the opponent. Address the hardest question. Close with impact.", bgClass: "bg-con/10", borderClass: "border-con/30", internal: false },
+              { phase: "7", label: "Judging", icon: "📊", desc: "Three specialized judges (Logic, Evidence, Engagement) score independently. Position-swapped for bias detection.", bgClass: "bg-surface-high", borderClass: "border-outline-variant", internal: false },
             ].map((step) => (
-              <div key={step.phase} className={`flex items-start gap-5 p-6 rounded-2xl transition-all hover:bg-white/[0.03] group ${step.internal ? "opacity-60 hover:opacity-100" : ""}`}>
-                <div className={`w-12 h-12 rounded-2xl ${step.bgClass} border ${step.borderClass} flex items-center justify-center text-xl shrink-0 group-hover:scale-110 transition-transform`}>
+              <div key={step.phase} className={`flex items-start gap-5 p-6 rounded-none transition-all hover:bg-surface-container group ${step.internal ? "opacity-60 hover:opacity-100" : ""}`}>
+                <div className={`w-12 h-12 rounded-none ${step.bgClass} border ${step.borderClass} flex items-center justify-center text-xl shrink-0`}>
                   {step.icon}
                 </div>
                 <div className="flex-1">
                   <div className="flex items-center gap-3 mb-1">
-                    <span className="text-base font-black text-white">{step.label}</span>
+                    <span className="text-base font-black text-on-surface font-headline">{step.label}</span>
                     {step.internal && (
-                      <span className="text-[10px] font-bold uppercase tracking-widest text-gray-600 bg-white/5 px-2 py-0.5 rounded-full border border-white/10">Internal</span>
+                      <span className="text-[10px] font-bold uppercase tracking-widest text-on-surface-variant bg-surface-high px-2 py-0.5 rounded-none border border-outline-variant">Internal</span>
                     )}
                   </div>
-                  <p className="text-sm text-gray-500 leading-relaxed">{step.desc}</p>
+                  <p className="text-sm text-on-surface-variant leading-relaxed font-body">{step.desc}</p>
                 </div>
               </div>
             ))}
@@ -367,24 +351,24 @@ function HomeInner() {
 
         {/* ═══ CTA Section ═══ */}
         <section className="px-6 py-24 max-w-4xl mx-auto w-full text-center">
-          <div className="rounded-[2.5rem] bg-gradient-to-br from-white/10 to-white/[0.02] border border-white/20 p-12 md:p-16 backdrop-blur-3xl shadow-[0_8px_60px_rgba(0,0,0,0.4)]">
-            <h2 className="text-3xl md:text-5xl font-black text-white mb-6 tracking-tight">
+          <div className="rounded-none bg-surface-container border border-outline-variant p-12 md:p-16">
+            <h2 className="text-3xl md:text-5xl font-black text-on-surface mb-6 tracking-tight font-headline">
               Stop hearing one side.
             </h2>
-            <p className="text-gray-400 text-lg max-w-xl mx-auto mb-10 leading-relaxed">
+            <p className="text-on-surface-variant text-lg max-w-xl mx-auto mb-10 leading-relaxed font-body">
               Every important topic has strong arguments on both sides. Most platforms hide that complexity. We put it front and center.
             </p>
             {isLoggedIn ? (
               <button
                 onClick={() => topicInputRef.current?.focus()}
-                className="px-10 py-5 bg-gradient-to-r from-cyan-500 to-blue-600 text-white hover:from-cyan-400 hover:to-blue-500 rounded-2xl font-black text-lg uppercase tracking-wider transition-all shadow-[0_4px_30px_rgba(6,182,212,0.4)] hover:shadow-[0_8px_40px_rgba(6,182,212,0.6)] hover:-translate-y-1"
+                className="px-10 py-5 bg-pro text-[#00195b] hover:opacity-90 rounded-none font-black text-lg uppercase tracking-wider transition-all"
               >
                 Start a Debate →
               </button>
             ) : (
               <Link
                 href="/auth"
-                className="inline-block px-10 py-5 bg-gradient-to-r from-fuchsia-600 to-purple-600 text-white hover:from-fuchsia-500 hover:to-purple-500 rounded-2xl font-black text-lg uppercase tracking-wider transition-all shadow-[0_4px_30px_rgba(217,70,239,0.3)] hover:shadow-[0_8px_40px_rgba(217,70,239,0.5)] hover:-translate-y-1"
+                className="inline-block px-10 py-5 bg-pro text-[#00195b] hover:opacity-90 rounded-none font-black text-lg uppercase tracking-wider transition-all"
               >
                 Create Free Account →
               </Link>
@@ -394,7 +378,7 @@ function HomeInner() {
       </main>
 
       {/* Footer */}
-      <footer className="relative z-10 py-8 border-t border-white/10 bg-black/20 backdrop-blur-md text-center text-sm font-semibold text-gray-500">
+      <footer className="relative z-10 py-8 border-t border-outline-variant bg-surface-low text-center text-sm font-semibold text-on-surface-variant">
         &copy; {new Date().getFullYear()} DebateMeBro. Open Source AI Debate Engine.
       </footer>
     </div>

--- a/frontend/src/components/dashboard/HistoryCard.tsx
+++ b/frontend/src/components/dashboard/HistoryCard.tsx
@@ -6,7 +6,7 @@ interface HistoryCardProps {
   /**
    * Temporarily optional until Issue #14 (Human Voting) is implemented.
    */
-  yourVote?: "pro" | "con"; 
+  yourVote?: "pro" | "con";
 }
 
 export default function HistoryCard({ debate, yourVote }: HistoryCardProps) {
@@ -18,46 +18,46 @@ export default function HistoryCard({ debate, yourVote }: HistoryCardProps) {
 
   const winner = debate.winner === "pro" ? "Pro" : debate.winner === "con" ? "Con" : null;
   const winnerColor = debate.winner === "pro"
-    ? "bg-cyan-500/20 text-cyan-400 border-cyan-500/30"
-    : "bg-fuchsia-500/20 text-fuchsia-400 border-fuchsia-500/30";
+    ? "bg-pro/10 text-pro border-pro/30"
+    : "bg-con/10 text-con border-con/30";
 
   return (
     <Link
       href={`/debates/${debate.id}`}
-      className="block group p-6 rounded-2xl bg-white/[0.03] border border-white/10 hover:bg-white/[0.06] hover:border-white/20 transition-all"
+      className="block group p-6 rounded-none bg-surface-container border border-outline-variant hover:bg-surface-high hover:border-outline transition-all"
     >
       <div className="flex items-start justify-between gap-4">
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-3 mb-1.5">
-            <h3 className="text-base font-bold text-white group-hover:text-cyan-300 transition-colors truncate">
+            <h3 className="text-base font-bold text-on-surface group-hover:text-pro transition-colors truncate">
               {debate.topic}
             </h3>
             {winner && (
-              <span className={`shrink-0 px-2.5 py-0.5 rounded-full text-[10px] font-black uppercase border ${winnerColor}`}>
+              <span className={`shrink-0 px-2.5 py-0.5 rounded-none text-[10px] font-black uppercase border ${winnerColor}`}>
                 {winner} wins
               </span>
             )}
           </div>
           {debate.resolution && (
-            <p className="text-xs text-gray-500 mb-2 truncate">{debate.resolution}</p>
+            <p className="text-xs text-on-surface-variant mb-2 truncate">{debate.resolution}</p>
           )}
-          <div className="flex items-center flex-wrap gap-4 text-xs text-gray-500">
+          <div className="flex items-center flex-wrap gap-4 text-xs text-on-surface-variant">
             <span>{formattedDate}</span>
             <span className="flex items-center gap-1">
-              <span className="w-2 h-2 rounded-full bg-cyan-400" />
+              <span className="w-2 h-2 rounded-none bg-pro" />
               Pro: {debate.pro_score?.toFixed(1) || "0.0"}
             </span>
             <span className="flex items-center gap-1">
-              <span className="w-2 h-2 rounded-full bg-fuchsia-400" />
+              <span className="w-2 h-2 rounded-none bg-con" />
               Con: {debate.con_score?.toFixed(1) || "0.0"}
             </span>
             {debate.turn_count > 0 && <span>{debate.turn_count} turns</span>}
             {yourVote && (
               <span
-                className={`px-2 py-0.5 rounded-full text-[10px] font-bold uppercase ${
+                className={`px-2 py-0.5 rounded-none text-[10px] font-bold uppercase ${
                   yourVote === "pro"
-                    ? "bg-cyan-500/20 text-cyan-400 border border-cyan-500/30"
-                    : "bg-fuchsia-500/20 text-fuchsia-400 border border-fuchsia-500/30"
+                    ? "bg-pro/10 text-pro border border-pro/30"
+                    : "bg-con/10 text-con border border-con/30"
                 }`}
               >
                 Voted {yourVote}
@@ -65,7 +65,7 @@ export default function HistoryCard({ debate, yourVote }: HistoryCardProps) {
             )}
           </div>
         </div>
-        <span className="text-gray-600 group-hover:text-gray-400 transition-colors text-sm">
+        <span className="text-on-surface-variant group-hover:text-on-surface transition-colors text-sm">
           →
         </span>
       </div>

--- a/frontend/src/components/debate/ArgumentCard.tsx
+++ b/frontend/src/components/debate/ArgumentCard.tsx
@@ -10,34 +10,27 @@ interface Props {
 
 export function ArgumentCard({ turn, persona, isStreaming }: Props) {
   const isPro = turn.side === "pro";
-  const glow = isPro ? "shadow-[0_0_40px_rgba(6,182,212,0.05)] hover:shadow-[0_0_50px_rgba(6,182,212,0.15)]" : "shadow-[0_0_40px_rgba(217,70,239,0.05)] hover:shadow-[0_0_50px_rgba(217,70,239,0.15)]";
-  const border = isPro ? "border-cyan-500/20 hover:border-cyan-500/40" : "border-fuchsia-500/20 hover:border-fuchsia-500/40";
-  const bg = "bg-white/[0.03]";
-  const iconBg = isPro ? "bg-gradient-to-br from-cyan-400 to-blue-600" : "bg-gradient-to-br from-fuchsia-400 to-purple-600";
-  const iconShadow = isPro ? "shadow-[0_0_20px_rgba(6,182,212,0.5)]" : "shadow-[0_0_20px_rgba(217,70,239,0.5)]";
-  const titleColor = isPro ? "text-cyan-400" : "text-fuchsia-400";
-  
-  return (
-    <div className={`mb-8 p-8 rounded-[2rem] border ${border} ${bg} ${glow} backdrop-blur-3xl transition-all duration-500 group relative overflow-hidden`}>
-      {/* Subtle corner glow */}
-      <div className={`absolute -top-10 -right-10 w-32 h-32 rounded-full blur-[60px] opacity-20 transition-opacity duration-500 group-hover:opacity-40 ${isPro ? "bg-cyan-500" : "bg-fuchsia-500"}`}></div>
+  const borderLeft = isPro ? "border-l-4 border-pro" : "border-l-4 border-con";
+  const titleColor = isPro ? "text-pro" : "text-con";
 
+  return (
+    <div className={`mb-8 p-8 rounded-none bg-surface-container ${borderLeft} transition-all duration-500 group relative overflow-hidden`}>
       <div className="flex items-center gap-5 mb-6 relative z-10">
-        <div className={`w-14 h-14 rounded-2xl ${iconBg} ${iconShadow} flex items-center justify-center text-xl font-black text-white`}>
+        <div className={`w-14 h-14 rounded-none flex items-center justify-center text-xl font-black ${isPro ? "bg-pro/20 text-pro" : "bg-con/20 text-con"}`}>
           {isPro ? "P" : "C"}
         </div>
         <div>
           <div className={`text-xl font-black ${titleColor} drop-shadow-sm`}>
             {persona?.name || (isPro ? "Pro Agent" : "Con Agent")}
           </div>
-          <div className="text-xs font-bold text-gray-500 uppercase tracking-widest mt-1">{persona?.role || "Synthesizing..."}</div>
+          <div className="text-xs font-bold text-on-surface-variant uppercase tracking-widest mt-1">{persona?.role || "Synthesizing..."}</div>
         </div>
       </div>
-      
-      <div className="relative z-10">
-        <StreamingText 
-          text={turn.text} 
-          citations={turn.citations || []} 
+
+      <div className="relative z-10 font-body">
+        <StreamingText
+          text={turn.text}
+          citations={turn.citations || []}
           isStreaming={isStreaming}
           side={turn.side}
         />

--- a/frontend/src/components/debate/CitationBadge.tsx
+++ b/frontend/src/components/debate/CitationBadge.tsx
@@ -21,32 +21,32 @@ function sanitizeCitationUrl(url: string): string {
 export function CitationBadge({ citationId, citations, isExpanded, onClick }: Props) {
   const citation = citations.find(c => c.id === citationId) || { id: citationId, url: "#" };
   const safeUrl = citation.url ? sanitizeCitationUrl(citation.url) : "#";
-  
+
   return (
     <span className="inline-block relative mx-1 align-baseline z-30">
-      <button 
+      <button
         onClick={onClick}
-        className={`inline-flex items-center gap-1.5 px-2.5 py-0.5 rounded-lg text-[11px] font-black tracking-widest transition-all cursor-pointer border shadow-sm uppercase
-          ${isExpanded 
-            ? "bg-emerald-500/20 text-emerald-300 border-emerald-400/50 shadow-[0_0_15px_rgba(52,211,153,0.3)] scale-105" 
-            : "bg-white/5 text-gray-300 hover:text-white hover:bg-white/10 hover:border-white/30 border-white/10"}`}
+        className={`inline-flex items-center gap-1.5 px-2.5 py-0.5 rounded-none text-[11px] font-black tracking-widest transition-all cursor-pointer border shadow-sm uppercase
+          ${isExpanded
+            ? "bg-pro/20 text-pro border-pro/50 scale-105"
+            : "bg-surface-high text-on-surface-variant hover:bg-surface-bright hover:border-outline-variant border-outline-variant"}`}
         title={citation.title || citation.id}
       >
-        <span className="text-emerald-400 text-[10px]">🌐</span> 
+        <span className="text-[10px]">🌐</span>
         {citation.id.length > 30 ? citation.id.slice(0, 30) + "..." : citation.id}
       </button>
-      
+
       {isExpanded && safeUrl !== "#" && (
-        <span className="absolute left-1/2 -translate-x-1/2 bottom-full mb-3 w-72 p-4 bg-slate-900/95 backdrop-blur-xl border border-emerald-500/40 rounded-2xl shadow-[0_10px_40px_rgba(0,0,0,0.5)] z-50 animate-in fade-in zoom-in duration-200">
-          <span className="block font-bold text-emerald-400 text-sm mb-2 break-words text-center">
-            <a href={safeUrl} target="_blank" rel="noopener noreferrer" className="hover:text-emerald-300 transition-colors underline decoration-emerald-500/30 underline-offset-4">
+        <span className="absolute left-1/2 -translate-x-1/2 bottom-full mb-3 w-72 p-4 bg-surface-bright border border-outline-variant rounded-none shadow-[0_10px_40px_rgba(0,0,0,0.5)] z-50 animate-in fade-in zoom-in duration-200">
+          <span className="block font-bold text-pro text-sm mb-2 break-words text-center">
+            <a href={safeUrl} target="_blank" rel="noopener noreferrer" className="hover:text-pro/80 transition-colors underline decoration-pro/30 underline-offset-4">
               {citation.title || citation.id}
             </a>
           </span>
-          <span className="block text-gray-400 text-[11px] mt-2 font-medium text-center">Verified Source • Click link to open</span>
-          
+          <span className="block text-on-surface-variant text-[11px] mt-2 font-medium text-center">Verified Source • Click link to open</span>
+
           {/* Triangle pointer border */}
-          <span className="absolute -bottom-2 left-1/2 -translate-x-1/2 border-spacing-4 border-l-8 border-r-8 border-t-8 border-transparent border-t-emerald-500/40 drop-shadow-lg"></span>
+          <span className="absolute -bottom-2 left-1/2 -translate-x-1/2 border-spacing-4 border-l-8 border-r-8 border-t-8 border-transparent border-t-outline-variant drop-shadow-lg"></span>
         </span>
       )}
     </span>

--- a/frontend/src/components/debate/PhaseNav.tsx
+++ b/frontend/src/components/debate/PhaseNav.tsx
@@ -12,25 +12,25 @@ export function PhaseNav({ onManualNav }: { onManualNav?: () => void } = {}) {
   );
 
   return (
-    <div className="flex items-center justify-center gap-2 px-6 py-3 bg-gradient-to-r from-slate-950/80 via-slate-900/60 to-slate-950/80 backdrop-blur-3xl border-b border-white/[0.06] overflow-x-auto w-full z-20">
+    <div className="flex items-center justify-center gap-2 px-6 py-3 bg-surface-low border-b border-outline-variant overflow-x-auto w-full z-20">
       {DEBATE_PHASES.map((phase, i) => {
         const isActive = activePhase === phase.id;
         const isComplete = completedPhases.includes(phase.id);
-        
+
         return (
           <div key={phase.id} className="flex items-center shrink-0">
             <button
               onClick={() => { if (isComplete || isActive) { setActivePhase(phase.id); onManualNav?.(); } }}
-              className={`flex items-center gap-2 px-4 py-2 rounded-full text-xs font-bold transition-all whitespace-nowrap border
-                ${isActive ? "bg-white/10 text-white border-white/30 shadow-[0_0_20px_rgba(255,255,255,0.1)] scale-105" 
-                  : isComplete ? "text-cyan-400 border-cyan-500/30 hover:bg-cyan-500/10 cursor-pointer" 
-                  : "text-gray-600 border-transparent cursor-default"} 
+              className={`flex items-center gap-2 px-4 py-2 rounded-none text-xs font-bold transition-all whitespace-nowrap border
+                ${isActive ? "bg-surface-bright text-on-surface border-l-2 border-pro"
+                  : isComplete ? "text-pro border-pro/30 hover:bg-surface-high cursor-pointer"
+                  : "text-on-surface-variant opacity-40 border-transparent cursor-default"}
                 ${phase.internal ? "italic font-semibold opacity-80" : "uppercase tracking-widest"}`}
             >
-              {isComplete && !isActive ? <span className="text-cyan-300">✓</span> : <span>{phase.icon}</span>}
+              {isComplete && !isActive ? <span className="text-pro">✓</span> : <span>{phase.icon}</span>}
               <span>{phase.label}</span>
             </button>
-            {i < DEBATE_PHASES.length - 1 && <span className="text-gray-700 mx-2">›</span>}
+            {i < DEBATE_PHASES.length - 1 && <span className="text-on-surface-variant mx-2">›</span>}
           </div>
         );
       })}

--- a/frontend/src/components/debate/StrategicAnalysisPanel.tsx
+++ b/frontend/src/components/debate/StrategicAnalysisPanel.tsx
@@ -10,7 +10,7 @@ function parseBold(text: string, keyPrefix: string): ReactNode[] {
   const segments = text.split(/(\*\*.*?\*\*)/g);
   return segments.map((seg, j) => {
     if (seg.startsWith("**") && seg.endsWith("**")) {
-      return <strong key={`${keyPrefix}-b${j}`} className="font-bold text-white">{seg.slice(2, -2)}</strong>;
+      return <strong key={`${keyPrefix}-b${j}`} className="font-bold text-on-surface">{seg.slice(2, -2)}</strong>;
     }
     return seg ? <span key={`${keyPrefix}-t${j}`}>{seg}</span> : null;
   }).filter(Boolean);
@@ -20,22 +20,22 @@ function renderMarkdownBlock(line: string, i: number): ReactNode {
   const trimmed = line.trimStart();
 
   if (/^-{3,}\s*$/.test(trimmed)) {
-    return <hr key={`hr-${i}`} className="border-white/10 my-4" />;
+    return <hr key={`hr-${i}`} className="border-outline-variant my-4" />;
   }
   if (trimmed.startsWith("### ")) {
-    return <h4 key={`h3-${i}`} className="text-base font-black text-white mt-5 mb-1.5 tracking-tight">{parseBold(trimmed.slice(4), `h3-${i}`)}</h4>;
+    return <h4 key={`h3-${i}`} className="text-base font-black text-on-surface mt-5 mb-1.5 tracking-tight">{parseBold(trimmed.slice(4), `h3-${i}`)}</h4>;
   }
   if (trimmed.startsWith("## ")) {
-    return <h3 key={`h2-${i}`} className="text-lg font-black text-white mt-6 mb-2 tracking-tight">{parseBold(trimmed.slice(3), `h2-${i}`)}</h3>;
+    return <h3 key={`h2-${i}`} className="text-lg font-black text-on-surface mt-6 mb-2 tracking-tight">{parseBold(trimmed.slice(3), `h2-${i}`)}</h3>;
   }
   if (trimmed.startsWith("# ")) {
-    return <h2 key={`h1-${i}`} className="text-xl font-black text-white mt-6 mb-2 tracking-tight">{parseBold(trimmed.slice(2), `h1-${i}`)}</h2>;
+    return <h2 key={`h1-${i}`} className="text-xl font-black text-on-surface mt-6 mb-2 tracking-tight">{parseBold(trimmed.slice(2), `h1-${i}`)}</h2>;
   }
   if (/^[-*]\s/.test(trimmed)) {
     return (
       <div key={`li-${i}`} className="flex gap-2.5 pl-2 mb-1">
-        <span className="text-gray-500 select-none shrink-0 mt-0.5">•</span>
-        <span className="text-sm text-gray-300 leading-relaxed">{parseBold(trimmed.slice(2), `li-${i}`)}</span>
+        <span className="text-on-surface-variant select-none shrink-0 mt-0.5">•</span>
+        <span className="text-sm text-on-surface-variant leading-relaxed">{parseBold(trimmed.slice(2), `li-${i}`)}</span>
       </div>
     );
   }
@@ -45,15 +45,15 @@ function renderMarkdownBlock(line: string, i: number): ReactNode {
     const rest = trimmed.replace(/^\d+\.\s/, "");
     return (
       <div key={`ol-${i}`} className="flex gap-2.5 pl-2 mb-1">
-        <span className="text-gray-500 select-none shrink-0 mt-0.5 font-mono text-xs">{num}.</span>
-        <span className="text-sm text-gray-300 leading-relaxed">{parseBold(rest, `ol-${i}`)}</span>
+        <span className="text-on-surface-variant select-none shrink-0 mt-0.5 font-mono text-xs">{num}.</span>
+        <span className="text-sm text-on-surface-variant leading-relaxed">{parseBold(rest, `ol-${i}`)}</span>
       </div>
     );
   }
   if (trimmed === "") {
     return <div key={`br-${i}`} className="h-2" />;
   }
-  return <p key={`p-${i}`} className="text-sm text-gray-300 leading-relaxed mb-1">{parseBold(trimmed, `p-${i}`)}</p>;
+  return <p key={`p-${i}`} className="text-sm text-on-surface-variant leading-relaxed mb-1">{parseBold(trimmed, `p-${i}`)}</p>;
 }
 
 export function StrategicAnalysisPanel({ content, side }: Props) {
@@ -64,14 +64,13 @@ export function StrategicAnalysisPanel({ content, side }: Props) {
     return content.split("\n").map((line, i) => renderMarkdownBlock(line, i));
   }, [content]);
 
-  const bgClass = side === "pro" ? "bg-cyan-900/20" : "bg-fuchsia-900/20";
-  const borderClass = side === "pro" ? "border-cyan-500/30" : "border-fuchsia-500/30";
-  const hoverClass = side === "pro" ? "hover:bg-cyan-900/40" : "hover:bg-fuchsia-900/40";
-  const textClass = side === "pro" ? "text-cyan-400" : "text-fuchsia-400";
-  const shadowClass = side === "pro" ? "shadow-[0_0_15px_rgba(6,182,212,0.1)]" : "shadow-[0_0_15px_rgba(217,70,239,0.1)]";
+  const bgClass = side === "pro" ? "bg-pro/20" : "bg-con/20";
+  const hoverClass = side === "pro" ? "hover:bg-pro/30" : "hover:bg-con/30";
+  const textClass = side === "pro" ? "text-pro" : "text-con";
+  const borderLeft = side === "pro" ? "border-l-2 border-pro" : "border-l-2 border-con";
 
   return (
-    <div className={`mt-4 border ${borderClass} rounded-2xl overflow-hidden backdrop-blur-3xl shadow-lg transition-all duration-300 ${shadowClass}`}>
+    <div className={`mt-4 rounded-none overflow-hidden transition-all duration-300 ${borderLeft}`}>
       <button
         onClick={() => setExpanded(!expanded)}
         className={`w-full flex items-center gap-3 px-5 py-3.5 text-xs font-black uppercase tracking-widest ${bgClass} ${hoverClass} transition-colors ${textClass}`}
@@ -81,8 +80,8 @@ export function StrategicAnalysisPanel({ content, side }: Props) {
         <span className={`ml-auto text-xs transition-transform ${expanded ? "rotate-180" : ""}`}>▼</span>
       </button>
       {expanded && (
-        <div className="px-6 py-5 bg-slate-950/80 shadow-inner max-h-[500px] overflow-y-auto border-t border-white/5 space-y-0.5">
-          {parsed || <span className="text-gray-500 italic animate-pulse text-sm">Computing strategy...</span>}
+        <div className="px-6 py-5 bg-surface-low shadow-inner max-h-[500px] overflow-y-auto border-t border-outline-variant space-y-0.5">
+          {parsed || <span className="text-on-surface-variant italic animate-pulse text-sm">Computing strategy...</span>}
         </div>
       )}
     </div>

--- a/frontend/src/components/debate/StreamingText.tsx
+++ b/frontend/src/components/debate/StreamingText.tsx
@@ -67,7 +67,7 @@ function parseBold(text: string, keyPrefix: string): ReactNode[] {
   const segments = text.split(/(\*\*.*?\*\*)/g);
   return segments.map((seg, j) => {
     if (seg.startsWith("**") && seg.endsWith("**")) {
-      return <strong key={`${keyPrefix}-b${j}`} className="font-bold text-white tracking-normal">{seg.slice(2, -2)}</strong>;
+      return <strong key={`${keyPrefix}-b${j}`} className="font-bold text-on-surface tracking-normal">{seg.slice(2, -2)}</strong>;
     }
     return seg ? <span key={`${keyPrefix}-t${j}`}>{seg}</span> : null;
   }).filter(Boolean);
@@ -80,36 +80,36 @@ export function StreamingText({ text, citations, isStreaming, side }: Props) {
     return text.split("\n");
   }, [text]);
 
-  const cursorColor = side === "pro" ? "bg-cyan-400 shadow-[0_0_10px_rgba(34,211,238,0.8)]" : "bg-fuchsia-400 shadow-[0_0_10px_rgba(232,121,249,0.8)]";
+  const cursorColor = side === "pro" ? "bg-pro" : "bg-con";
 
   return (
-    <div className="text-base leading-relaxed text-gray-200 font-medium tracking-wide space-y-1">
+    <div className="font-body text-base leading-relaxed text-on-surface-variant font-medium tracking-wide space-y-1">
       {blocks.map((line, i) => {
         const trimmed = line.trimStart();
 
         // Horizontal rule
         if (/^-{3,}\s*$/.test(trimmed)) {
-          return <hr key={`hr-${i}`} className="border-white/10 my-4" />;
+          return <hr key={`hr-${i}`} className="border-outline-variant my-4" />;
         }
 
         // Headings
         if (trimmed.startsWith("### ")) {
           return (
-            <h4 key={`h3-${i}`} className="text-base font-black text-white mt-4 mb-1 tracking-tight">
+            <h4 key={`h3-${i}`} className="text-base font-black text-on-surface mt-4 mb-1 tracking-tight">
               {parseInline(trimmed.slice(4), citations, expandedCitation, setExpandedCitation, `h3-${i}`)}
             </h4>
           );
         }
         if (trimmed.startsWith("## ")) {
           return (
-            <h3 key={`h2-${i}`} className="text-lg font-black text-white mt-5 mb-1.5 tracking-tight">
+            <h3 key={`h2-${i}`} className="text-lg font-black text-on-surface mt-5 mb-1.5 tracking-tight">
               {parseInline(trimmed.slice(3), citations, expandedCitation, setExpandedCitation, `h2-${i}`)}
             </h3>
           );
         }
         if (trimmed.startsWith("# ")) {
           return (
-            <h2 key={`h1-${i}`} className="text-xl font-black text-white mt-6 mb-2 tracking-tight">
+            <h2 key={`h1-${i}`} className="text-xl font-black text-on-surface mt-6 mb-2 tracking-tight">
               {parseInline(trimmed.slice(2), citations, expandedCitation, setExpandedCitation, `h1-${i}`)}
             </h2>
           );
@@ -119,7 +119,7 @@ export function StreamingText({ text, citations, isStreaming, side }: Props) {
         if (/^[-*]\s/.test(trimmed)) {
           return (
             <div key={`li-${i}`} className="flex gap-2 pl-2">
-              <span className="text-gray-500 select-none shrink-0">•</span>
+              <span className="text-on-surface-variant select-none shrink-0">•</span>
               <span>{parseInline(trimmed.slice(2), citations, expandedCitation, setExpandedCitation, `li-${i}`)}</span>
             </div>
           );
@@ -132,7 +132,7 @@ export function StreamingText({ text, citations, isStreaming, side }: Props) {
           const rest = trimmed.replace(/^\d+\.\s/, "");
           return (
             <div key={`ol-${i}`} className="flex gap-2 pl-2">
-              <span className="text-gray-500 select-none shrink-0">{num}.</span>
+              <span className="text-on-surface-variant select-none shrink-0">{num}.</span>
               <span>{parseInline(rest, citations, expandedCitation, setExpandedCitation, `ol-${i}`)}</span>
             </div>
           );
@@ -151,7 +151,7 @@ export function StreamingText({ text, citations, isStreaming, side }: Props) {
         );
       })}
       {isStreaming && (
-        <span className={`inline-block w-2.5 h-4 ml-1 align-middle animate-pulse rounded-sm ${cursorColor}`}></span>
+        <span className={`inline-block w-2.5 h-4 ml-1 align-middle animate-pulse rounded-none ${cursorColor}`}></span>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary

- Replaces the old cyan/fuchsia gradient aesthetic with the **Intellectual Modernism / Digital Rostrum** design system
- Introduces a full design token layer in `globals.css` (surface hierarchy, pro/con accents, three-font system)
- Pure visual refactor — all logic, state (Zustand), API calls, and SSE streaming are untouched

## Changes

**Design tokens & fonts (`globals.css`, `layout.tsx`)**
- New surface color hierarchy: `#0e0e0e` → `#131313` → `#191a1a` → `#1f2020` → `#252626` → `#2b2c2c`
- Pro accent: `#7c98ff` (sapphire blue), Con accent: `#ff7168` (coral red)
- Three-font system: Space Grotesk (headlines), Newsreader serif (argument body), Inter (UI labels)
- Tailwind v4 `@theme inline` maps all tokens to utility classes (`bg-pro`, `text-con`, `bg-surface-container`, etc.)

**Pages restyled** (no functional changes)
- `page.tsx` — removed animated blobs, sharp hero, token-based input/buttons
- `auth/page.tsx` — sharp form, flat buttons, underline tab indicator
- `dashboard/page.tsx` — sharp cards with left-border accents
- `browse/page.tsx` — sharp card grid, like button, filter pills
- `debates/new/page.tsx` — sharp wizard steps, `border-l-4` research cards
- `debates/[id]/page.tsx` — ScoreBar, JudgeCard, split-screen arena, voting section all restyled

**Components restyled**
- `ArgumentCard` — `border-l-4 border-pro/con`, `font-body` on argument text
- `PhaseNav` — `bg-surface-bright border-l-2 border-pro` active state
- `CitationBadge`, `StrategicAnalysisPanel`, `StreamingText`, `HistoryCard` — all updated to token system

**Lint fixes**
- `debates/[id]/page.tsx`: replaced `<a href="/">` with `<Link />`, typed `catch (e: unknown)`

## Test plan

- [ ] Visit `/` — sharp home, no blobs, Space Grotesk headline
- [ ] Visit `/auth` — sharp form, flat buttons
- [ ] Visit `/dashboard` — sharp cards, left-border accents
- [ ] Visit `/browse` — sharp card grid, filter pills
- [ ] Visit `/debates/new` — wizard with sharp steps
- [ ] Visit `/debates/{id}` — split arena, Newsreader argument text, sharp judge cards
- [ ] `DEBATE_MODE=demo` works without API keys
- [ ] `npm run lint` — no new errors
- [ ] Pro/Con colors: `#7c98ff` blue for Pro, `#ff7168` coral for Con
- [ ] No rounded corners anywhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)